### PR TITLE
Add script to update VM notes from VM Tools status/version

### DIFF
--- a/powershell/clean-iso-folders.ps1
+++ b/powershell/clean-iso-folders.ps1
@@ -130,7 +130,7 @@ try
 			# bidon sinon c'est affiché à l'écran.
 			$dummy = Set-PowerCLIConfiguration -InvalidCertificateAction Ignore -Confirm:$false
 
-			$vCenter = Connect-VIServer -Server $global:VSPHERE_HOST -user $global:VSPHERE_USERNAME -Password $global:VSPHERE_PASSWORD
+			$vCenter = Connect-VIServer -Server $global:VSPHERE_HOST -user $global:VSPHERE_RO_USERNAME -Password $global:VSPHERE_RO_PASSWORD
 		}
 		
 		# Recherche des infos du BG

--- a/powershell/config-vsphere-sample.inc.ps1
+++ b/powershell/config-vsphere-sample.inc.ps1
@@ -11,5 +11,11 @@
 
 # vSphere
 $global:VSPHERE_HOST     = ""
-$global:VSPHERE_USERNAME = ""
-$global:VSPHERE_PASSWORD = ""
+
+# Utilisateur Read-Only
+$global:VSPHERE_RO_USERNAME = ""
+$global:VSPHERE_RO_PASSWORD = ""
+
+# Utilisateur Read-Write
+$global:VSPHERE_RW_USERNAME = ""
+$global:VSPHERE_RW_PASSWORD = ""

--- a/powershell/include/vsphere/functions.inc.ps1
+++ b/powershell/include/vsphere/functions.inc.ps1
@@ -1,0 +1,54 @@
+<# 
+    BUT : Contient des fonctions utilisant vSphere qui sont utilisées par beaucoup de scripts PowerShell différents.
+        Elles ont été regroupées dans un seul et même fichier afin d'éviter les copier-coller dans
+        chaque script les nécessitant.
+ 
+  AUTEUR : Lucien Chaboudez
+  DATE   : 27.05.2019
+ 
+ UTILISATION : Il suffit d'ajouter une ligne comme ceci au début du script qui a besoin des fonctions :
+ . "<pathToScript>func.inc.ps1"
+ 
+ ------
+ HISTORIQUE DES VERSIONS
+ 1.0 - Version de base
+ 
+ 
+#>
+
+
+<#
+   BUT : Charge (si besoin) les modules PowerCli permettant de se connecter à vSphere
+#>
+function loadPowerCliModules
+{
+   #Save the current value in the $p variable.
+   $p = [Environment]::GetEnvironmentVariable("PSModulePath")
+
+   # Par défaut, le chemin où se trouvent les modules PowerCLI ne se trouve pas dans le Path. 
+   # On ajoute donc le nécessaire.
+   $p += ";C:\Program Files (x86)\VMware\Infrastructure\PowerCLI\Modules\"
+
+   #Add the paths in $p to the PSModulePath value.
+   [Environment]::SetEnvironmentVariable("PSModulePath",$p)
+
+   # Si module pas encore chargé, 
+   if(!(Get-Module VMware.VimAutomation.Core))
+   {
+      try
+      {
+         Write-Host "Loading module 'VMware.VimAutomation.Core'... " -NoNewline
+         Import-Module VMware.VimAutomation.Core
+         Write-Host "done"
+      }
+      catch
+      {
+         Write-Error "VMware.VimAutomation.Core module is not installed"
+         exit
+      }
+   }
+   else
+   {
+      Write-Host "Module 'VMware.VimAutomation.Core' already loaded"
+   }
+}

--- a/powershell/vsphere-update-vm-notes-with-tools-version.ps1
+++ b/powershell/vsphere-update-vm-notes-with-tools-version.ps1
@@ -1,0 +1,142 @@
+<#
+	BUT 		: Met à jour les notes des VM en fonction de l'état des VM Tools
+
+	DATE 		: Mai 2019
+	AUTEUR 	: Lucien Chaboudez
+
+	REMARQUE : Avant de pouvoir exécuter ce script, il faudra changer la ExecutionPolicy
+				  via Set-ExecutionPolicy. Normalement, si on met la valeur "Unrestricted",
+				  cela suffit à correctement faire tourner le script. Mais il se peut que
+				  si le script se trouve sur un share réseau, l'exécution ne passe pas et
+				  qu'il soit demandé d'utiliser "Unblock-File" pour permettre l'exécution.
+				  Ceci ne fonctionne pas ! A la place il faut à nouveau passer par la
+				  commande Set-ExecutionPolicy mais mettre la valeur "ByPass" en paramètre.
+#>
+
+
+
+# Inclusion des fichiers nécessaires (génériques)
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "functions.inc.ps1"))
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "Counters.inc.ps1"))
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "LogHistory.inc.ps1"))
+# Fichiers propres au script courant 
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "vsphere", "functions.inc.ps1"))
+
+
+# Chargement des fichiers de configuration
+loadConfigFile([IO.Path]::Combine("$PSScriptRoot", "config-vsphere.inc.ps1"))
+loadConfigFile([IO.Path]::Combine("$PSScriptRoot", "config-mail.inc.ps1"))
+
+
+# -------------------------------------------- CONSTANTES ---------------------------------------------------
+
+# Texte qui sépare les notes
+$VM_NOTE_SEPARATOR="## VMware Tools ##"
+
+
+# -------------------------------------------- FONCTIONS ---------------------------------------------------
+
+function getUpdatedNote()
+{
+    param([PSObject]$vm)
+
+    $note = $vm.Notes
+
+    # Si la note contient déjà les détails, 
+    if($note -match $VM_NOTE_SEPARATOR)
+    {
+        # on supprime ceux-ci 
+        $note = $note -replace ("\n?{0}[\n\d\s\w:-_,\.]*" -f $VM_NOTE_SEPARATOR)
+    }
+
+    # Définition d'un texte de statut en fonction de celui renvoyé par vSphere
+    $status = Switch ($vm.Guest.ExtensionData.ToolsVersionStatus)
+    {
+        "guestToolsUnmanaged"       { "Guest Managed" }
+        "guestToolsNeedUpgrade"     { "Upgrade available" }
+        "guestToolsNotInstalled"    { "Not installed" }
+        "guestToolsCurrent"         { "Up-to-date" }
+    }
+
+    # Ajout des détails
+    return ("{0}`n{1}`nVersion: {2}`nStatus: {3}" -f $note, $VM_NOTE_SEPARATOR, $vm.Guest.ToolsVersion, $status).trim()
+}
+
+
+
+
+# ----------------------------------------------------------------------------------------------------------------------
+# ----------------------------------------------------------------------------------------------------------------------
+# ---------------------------------------------- PROGRAMME PRINCIPAL ---------------------------------------------------
+# ----------------------------------------------------------------------------------------------------------------------
+# ----------------------------------------------------------------------------------------------------------------------
+try
+{
+
+	# Création d'un objet pour gérer les compteurs (celui-ci sera accédé en variable globale même si c'est pas propre XD)
+	$counters = [Counters]::new()
+
+	# Tous les Tenants
+    $counters.add('VMNotesUpdated', '# VM notes updated')
+    $counters.add('VMNotesOK', '# VM notes OK')
+
+    # Création de l'objet pour logguer les exécutions du script (celui-ci sera accédé en variable globale même si c'est pas propre XD)
+    $logHistory = [LogHistory]::new('vsphere - update VM notes with Tools version', (Join-Path $PSScriptRoot "logs"), 30)
+    
+    # Chargement des modules PowerCLI pour pouvoir accéder à vSphere.
+    loadPowerCliModules
+
+    # Connexion au serveur vSphere
+    $connectedvCenter = Connect-VIServer -Server $global:VSPHERE_HOST -user $global:VSPHERE_RW_USERNAME -Password $global:VSPHERE_RW_PASSWORD
+
+    $logHistory.addLineAndDisplay("Getting VMs...")
+
+    # Parcours des VM existantes
+    Foreach($vm in get-vm )
+    {
+
+        $logLine = ("VM {0}..." -f $vm.Name)
+
+        # Génération de la note 
+        $newNote = (getUpdatedNote -vm $vm)
+
+        # S'il faut mettre à jour la note, 
+        if($vm.Notes -ne $newNote)
+        {
+            $logHistory.addLineAndDisplay("{0} Updating" -f $logLine)
+
+            $dummy = Set-Vm $vm -Notes $newNote -Confirm:$false
+            $counters.inc('VMNotesUpdated')
+        }
+        else # Pas besoin de mettre à jour. 
+        {
+            $logHistory.addLineAndDisplay("{0} Notes OK" -f $logLine)
+            $counters.inc('VMNotesOK')
+        }
+        break
+
+    }# FIN BOUCLE de parcours des VM existantes
+
+
+    $logHistory.addLineAndDisplay($counters.getDisplay("Counters summary"))
+
+}
+catch
+{
+	# Récupération des infos
+	$errorMessage = $_.Exception.Message
+	$errorTrace = $_.ScriptStackTrace
+
+	$logHistory.addErrorAndDisplay(("An error occured: `nError: {0}`nTrace: {1}" -f $errorMessage, $errorTrace))
+	
+	# Envoi d'un message d'erreur aux admins 
+	$mailSubject = getvRAMailSubject -shortSubject ("Error in script '{0}'" -f $MyInvocation.MyCommand.Name) -targetEnv $targetEnv -targetTenant $targetTenant
+	$mailMessage = getvRAMailContent -content ("<b>Script:</b> {0}<br><b>Error:</b> {1}<br><b>Trace:</b> <pre>{2}</pre>" -f `
+	$MyInvocation.MyCommand.Name, $errorMessage, [System.Web.HttpUtility]::HtmlEncode($errorTrace))
+
+	sendMailTo -mailAddress $global:ADMIN_MAIL_ADDRESS -mailSubject $mailSubject -mailMessage $mailMessage
+}
+
+
+# Déconnexion du serveur vCenter
+Disconnect-VIServer  -Server $connectedvCenter -Confirm:$false 


### PR DESCRIPTION
- Mise à jour du fichier d'exemple avec les informations de connexion à vSphere (`config-vsphere-sample.inc.ps1`)
- Mise à jour du script de nettoyage des ISO pour utiliser les nouveaux noms de variable pour le username/password
- Ajout d'un script de mise à jour des notes des VM en fonction du statut/version des Tools de celle-ci (`vsphere-update-vm-notes-with-tools-version.ps1`)

*MISE EN PRODUCTION*
Il faut mettre à jour le fichier `config-vsphere.inc.ps1` pour :
- ajouter les informations de l'utilisateur RW
- changer les noms des variables pour le nom d'utilisateur et le mot de passe Read-Only