### PR TITLE
vSphere connection using -credential parameter

### DIFF
--- a/powershell/clean-iso-folders.ps1
+++ b/powershell/clean-iso-folders.ps1
@@ -133,7 +133,10 @@ try
 			# bidon sinon c'est affiché à l'écran.
 			$dummy = Set-PowerCLIConfiguration -InvalidCertificateAction Ignore -Confirm:$false
 
-			$vCenter = Connect-VIServer -Server $global:VSPHERE_HOST -user $global:VSPHERE_USERNAME -Password $global:VSPHERE_PASSWORD
+			$credSecurePwd = $global:VSPHERE_PASSWORD | ConvertTo-SecureString -AsPlainText -Force
+			$credObject = New-Object System.Management.Automation.PSCredential -ArgumentList $global:VSPHERE_USERNAME, $credSecurePwd	
+
+			$vCenter = Connect-VIServer -Server $global:VSPHERE_HOST -Credential $credObject
 		}
 		
 		# Recherche des infos du BG

--- a/powershell/vsphere-update-vm-notes-with-tools-version.ps1
+++ b/powershell/vsphere-update-vm-notes-with-tools-version.ps1
@@ -93,7 +93,11 @@ try
     $dummy = Set-PowerCLIConfiguration -Scope User -ParticipateInCEIP $false -Confirm:$false
 
     # Connexion au serveur vSphere
-    $connectedvCenter = Connect-VIServer -Server $global:VSPHERE_HOST -user $global:VSPHERE_USERNAME -Password $global:VSPHERE_PASSWORD
+
+    $credSecurePwd = $global:VSPHERE_PASSWORD | ConvertTo-SecureString -AsPlainText -Force
+    $credObject = New-Object System.Management.Automation.PSCredential -ArgumentList $global:VSPHERE_USERNAME, $credSecurePwd	
+            
+    $connectedvCenter = Connect-VIServer -Server $global:VSPHERE_HOST -Credential $credObject
 
     $logHistory.addLineAndDisplay("Getting VMs...")
 

--- a/powershell/xaas-backup-endpoints.ps1
+++ b/powershell/xaas-backup-endpoints.ps1
@@ -260,10 +260,15 @@ try
     # bidon sinon c'est affiché à l'écran.
     $dummy = Set-PowerCLIConfiguration -InvalidCertificateAction Ignore -Confirm:$false
 
-    # Connexion au serveur vSphere
-    $connectedvCenter = Connect-VIServer -Server $global:XAAS_BACKUP_VCENTER_SERVER_LIST[$targetEnv] `
-                                         -user $global:XAAS_BACKUP_VCENTER_USER_LIST[$targetEnv] `
-                                         -Password $global:XAAS_BACKUP_VCENTER_PASSWORD_LIST[$targetEnv]
+    
+	# On encrypte le mot de passe
+	$credSecurePwd = $global:XAAS_BACKUP_VCENTER_PASSWORD_LIST[$targetEnv] | ConvertTo-SecureString -AsPlainText -Force
+	$credObject = New-Object System.Management.Automation.PSCredential -ArgumentList $global:XAAS_BACKUP_VCENTER_USER_LIST[$targetEnv], $credSecurePwd
+
+    # Connexion au serveur vSphere.
+    # On passe par le paramètre -credential car sinon, on a des erreurs avec Get-AssignmentTag et Get-Tag, ou peut-être tout simplement avec les commandes dans
+    # lesquelles on faite un | pour passer à la suivante.
+    $connectedvCenter = Connect-VIServer -Server $global:XAAS_BACKUP_VCENTER_SERVER_LIST[$targetEnv] -credential $credObject
 
     # Connexion à l'API REST de NetBackup
     $nbu = [NetBackupAPI]::new($global:XAAS_BACKUP_SERVER_LIST[$targetEnv], $global:XAAS_BACKUP_USER_LIST[$targetEnv], $global:XAAS_BACKUP_PASSWORD_LIST[$targetEnv])   


### PR DESCRIPTION
Utilisation du paramètre `-credential` pour se connecter à vSphere car le fait d'utiliser `-user` et `-password` fait que les commandes pipées `|` ne fonctionnent plus... (pourquoi, aucune idée..)