### PR TITLE
Move headers in parent class

### DIFF
--- a/powershell/include/REST/NSXAPI.inc.ps1
+++ b/powershell/include/REST/NSXAPI.inc.ps1
@@ -27,8 +27,7 @@ class NSXAPI: RESTAPICurl
 	#>
 	NSXAPI([string] $server, [string] $username, [string] $password) : base($server) # Ceci appelle le constructeur parent
 	{
-        $this.headers = @{}
-		$this.headers.Add('Accept', 'application/json')
+        $this.headers.Add('Accept', 'application/json')
         $this.headers.Add('Content-Type', 'application/json')
         
         $this.authInfos = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(("{0}:{1}" -f $username,$password)))

--- a/powershell/include/REST/NetBackupAPI.inc.ps1
+++ b/powershell/include/REST/NetBackupAPI.inc.ps1
@@ -32,7 +32,6 @@ $global:NETBACKUP_API_PAGE_LIMIT_MAX = 99
 class NetBackupAPI: RESTAPICurl
 {
 	hidden [string]$token
-	hidden [System.Collections.Hashtable]$headers
 	
 
 	<#
@@ -48,7 +47,6 @@ class NetBackupAPI: RESTAPICurl
 	{
 		$this.server = $server
 
-		$this.headers = @{}
 		<# Le plus souvent, on utilise 'application/json' pour les 'Accept' et 'Content-Type' mais NetBackup semble vouloir faire
 			autrement... du coup, obligé de mettre ceci car sinon cela génère des erreurs. Et au final, c'est toujours du JSON... #>
 		$this.headers.Add('Accept', 'application/vnd.netbackup+json;version=2.0')

--- a/powershell/include/REST/RESTAPI.inc.ps1
+++ b/powershell/include/REST/RESTAPI.inc.ps1
@@ -15,7 +15,8 @@
 #>
 class RESTAPI
 {
-    hidden [string]$server
+	hidden [string]$server
+	hidden [System.Collections.Hashtable]$headers
 
     <#
 	-------------------------------------------------------------------------------------
@@ -25,7 +26,8 @@ class RESTAPI
 	#>
     RESTAPI([string] $server)
     {
-        $this.server = $server
+		$this.server = $server
+		$this.headers = @{}
     }
 
 

--- a/powershell/include/REST/RESTAPICurl.inc.ps1
+++ b/powershell/include/REST/RESTAPICurl.inc.ps1
@@ -25,7 +25,7 @@
 #>
 class RESTAPICurl: RESTAPI
 {
-	hidden [System.Collections.Hashtable]$headers
+	
 	hidden [System.Diagnostics.Process]$curl
 	hidden [PSObject]$process
 	

--- a/powershell/include/REST/vRAAPI.inc.ps1
+++ b/powershell/include/REST/vRAAPI.inc.ps1
@@ -22,7 +22,6 @@ class vRAAPI: RESTAPI
 {
 	hidden [string]$token
 	hidden [string]$tenant
-	hidden [System.Collections.Hashtable]$headers
 
 	<#
 	-------------------------------------------------------------------------------------
@@ -39,7 +38,6 @@ class vRAAPI: RESTAPI
 		$this.server = $server
 		$this.tenant = $tenant
 
-		$this.headers = @{}
 		$this.headers.Add('Accept', 'application/json')
 		$this.headers.Add('Content-Type', 'application/json')
 


### PR DESCRIPTION
Déplacement de `$this.headers` depuis les classes enfants jusque dans la classe parente `RESTAPI`.