### PR TITLE
Give 'body' as parameter instead of JSON

### DIFF
--- a/powershell/include/REST/NSXAPI.inc.ps1
+++ b/powershell/include/REST/NSXAPI.inc.ps1
@@ -58,7 +58,7 @@ class NSXAPI: RESTAPICurl
     {
         $uri = "https://{0}/api/v1/ns-groups/{1}" -f $this.server, $id
 
-        return $this.callAPI($uri, "Get", "")
+        return $this.callAPI($uri, "Get", $null)
         
     }
 
@@ -79,7 +79,7 @@ class NSXAPI: RESTAPICurl
     {
         $uri = "https://{0}/api/v1/ns-groups/?populate_references=false" -f $this.server
 
-        $id =  ($this.callAPI($uri, "Get", "").results | Where-Object {$_.display_name -eq $name}).id
+        $id =  ($this.callAPI($uri, "Get", $null).results | Where-Object {$_.display_name -eq $name}).id
      
         if($null -eq $id)
         {
@@ -113,7 +113,7 @@ class NSXAPI: RESTAPICurl
         $body = $this.loadJSON("nsx-nsgroup.json", $replace)
         
 		# Création du NS Group
-        $res = $this.callAPI($uri, "Post", (ConvertTo-Json -InputObject $body -Depth 20))       
+        $dummy = $this.callAPI($uri, "Post", $body)
         
         # Retour du NS Group en le cherchant par son nom
         return $this.getNSGroupByName($name)
@@ -155,7 +155,7 @@ class NSXAPI: RESTAPICurl
 		$uri = "https://{0}/api/v1/firewall/sections?filter_type={1}&page_size=1000&search_invalid_references=false&type={2}" -f $this.server, $filterType, $type
 
         # Récupération de la liste
-		$sectionList = $this.callAPI($uri, "GET", "").results
+		$sectionList = $this.callAPI($uri, "GET", $null).results
         
         # Retour de celui-ci
         return $sectionList | Where-Object {$_.display_name -eq $name }
@@ -187,7 +187,7 @@ class NSXAPI: RESTAPICurl
         $uri = "https://{0}/api/v1/firewall/sections/{1}" -f $this.server, $id
 
         # Création du NSGroup
-		return $this.callAPI($uri, "GET", "")
+		return $this.callAPI($uri, "GET", $null)
     }
 
 
@@ -220,7 +220,7 @@ class NSXAPI: RESTAPICurl
         $body = $this.loadJSON("nsx-firewall-section.json", $replace)
         
 		# Création de la section de firewall
-        return $this.callAPI($uri, "Post", (ConvertTo-Json -InputObject $body -Depth 20))       
+        return $this.callAPI($uri, "Post", $body)
     }
 
 
@@ -236,7 +236,7 @@ class NSXAPI: RESTAPICurl
         $uri = "https://{0}/api/v1/firewall/sections/{1}" -f $this.server, $id
         
 		# Création de la section de firewall
-        $res = $this.callAPI($uri, "Delete", "")       
+        $dummy = $this.callAPI($uri, "Delete", $null)       
         
     }
 
@@ -275,7 +275,7 @@ class NSXAPI: RESTAPICurl
         $body = $this.loadJSON("nsx-firewall-section-lock.json", $replace)
 
         # Verrouillage de la section
-        return $this.callAPI($uri, "POST", (ConvertTo-Json -InputObject $body -Depth 20))   
+        return $this.callAPI($uri, "POST", $body)
     }
 
 
@@ -300,7 +300,7 @@ class NSXAPI: RESTAPICurl
     {
         $uri = "https://{0}/api/v1/firewall/sections/{1}/rules" -f $this.server, $firewallSectionId
 
-        return $this.callAPI($uri, "GET", "").results
+        return $this.callAPI($uri, "GET", $null).results
     }
 
     <#
@@ -327,7 +327,7 @@ class NSXAPI: RESTAPICurl
         $body = $this.loadJSON("nsx-firewall-section-rules.json", $replace)
 
         # Création des règles
-        $res = $this.callAPI($uri, "Post", (ConvertTo-Json -InputObject $body -Depth 20))       
+        $dummy = $this.callAPI($uri, "Post", $body)
     }
 
 }

--- a/powershell/include/REST/NSXAPI.inc.ps1
+++ b/powershell/include/REST/NSXAPI.inc.ps1
@@ -110,7 +110,7 @@ class NSXAPI: RESTAPICurl
 					description = $desc
 					tag = $tag}
 
-        $body = $this.loadJSON("nsx-nsgroup.json", $replace)
+        $body = $this.createObjectFromJSON("nsx-nsgroup.json", $replace)
         
 		# Création du NS Group
         $dummy = $this.callAPI($uri, "Post", $body)
@@ -217,7 +217,7 @@ class NSXAPI: RESTAPICurl
 		$replace = @{name = $name
 					desc = $desc}
 
-        $body = $this.loadJSON("nsx-firewall-section.json", $replace)
+        $body = $this.createObjectFromJSON("nsx-firewall-section.json", $replace)
         
 		# Création de la section de firewall
         return $this.callAPI($uri, "Post", $body)
@@ -272,7 +272,7 @@ class NSXAPI: RESTAPICurl
         # Valeur à mettre pour la configuration de la section de firewall
 		$replace = @{sectionRevision = $section._revision}
 
-        $body = $this.loadJSON("nsx-firewall-section-lock.json", $replace)
+        $body = $this.createObjectFromJSON("nsx-firewall-section-lock.json", $replace)
 
         # Verrouillage de la section
         return $this.callAPI($uri, "POST", $body)
@@ -324,7 +324,7 @@ class NSXAPI: RESTAPICurl
                      nsGroupName            = $nsGroup.display_name
                      nsGroupId              = $nsGroup.id}
 
-        $body = $this.loadJSON("nsx-firewall-section-rules.json", $replace)
+        $body = $this.createObjectFromJSON("nsx-firewall-section-rules.json", $replace)
 
         # Création des règles
         $dummy = $this.callAPI($uri, "Post", $body)

--- a/powershell/include/REST/RESTAPI.inc.ps1
+++ b/powershell/include/REST/RESTAPI.inc.ps1
@@ -38,20 +38,22 @@ class RESTAPI
 
 		IN  : $uri		-> URL à appeler
 		IN  : $method	-> Méthode à utiliser (Post, Get, Put, Delete)
-		IN  : $json 	-> Code JSON
+		IN  : $body 	-> Objet à passer en Body de la requête. On va ensuite le transformer en JSON
+						 	Si $null, on ne passe rien.
 
 		RET : Retour de l'appel
 
 		REMARQUE: Si on a un retour autre qu'un code 200 lors de l'appel à Invoke-RestMethod, 
 					cela fait qu'on passe directement dans le bloc "catch"
 	#>
-	hidden [Object] callAPI([string]$uri, [string]$method, [string]$json)
+	hidden [Object] callAPI([string]$uri, [string]$method, [PSObject]$body)
 	{
 		try
 		{
-			if($json -ne "")
+			if($null -ne $body)
 			{
-				return Invoke-RestMethod -Uri $uri -Method $method -Headers $this.headers -Body $json
+				# On converti l'objet du Body en JSON pour faire la requête
+				return Invoke-RestMethod -Uri $uri -Method $method -Headers $this.headers -Body (ConvertTo-Json -InputObject $body -Depth 20)
 			}
 			else 
 			{

--- a/powershell/include/REST/RESTAPI.inc.ps1
+++ b/powershell/include/REST/RESTAPI.inc.ps1
@@ -114,7 +114,7 @@ class RESTAPI
 
 		RET : Objet créé depuis le code JSON
 	#>
-	hidden [Object] loadJSON([string] $file, [System.Collections.IDictionary] $valToReplace)
+	hidden [Object] createObjectFromJSON([string] $file, [System.Collections.IDictionary] $valToReplace)
 	{
 		# Chemin complet jusqu'au fichier à charger
 		$filepath = (Join-Path $global:JSON_TEMPLATE_FOLDER $file)

--- a/powershell/include/REST/RESTAPI.inc.ps1
+++ b/powershell/include/REST/RESTAPI.inc.ps1
@@ -46,14 +46,15 @@ class RESTAPI
 		REMARQUE: Si on a un retour autre qu'un code 200 lors de l'appel à Invoke-RestMethod, 
 					cela fait qu'on passe directement dans le bloc "catch"
 	#>
-	hidden [Object] callAPI([string]$uri, [string]$method, [PSObject]$body)
+	hidden [Object] callAPI([string]$uri, [string]$method, [System.Object]$body)
 	{
 		try
 		{
 			if($null -ne $body)
 			{
 				# On converti l'objet du Body en JSON pour faire la requête
-				return Invoke-RestMethod -Uri $uri -Method $method -Headers $this.headers -Body (ConvertTo-Json -InputObject $body -Depth 20)
+				$json = ConvertTo-Json -InputObject $body -Depth 20
+				return Invoke-RestMethod -Uri $uri -Method $method -Headers $this.headers -Body $json
 			}
 			else 
 			{

--- a/powershell/include/REST/RESTAPICurl.inc.ps1
+++ b/powershell/include/REST/RESTAPICurl.inc.ps1
@@ -108,22 +108,23 @@ class RESTAPICurl: RESTAPI
 
 		IN  : $uri		-> URL à appeler
 		IN  : $method	-> Méthode à utiliser (Post, Get, Put, Delete)
-		IN  : $json 	-> Code JSON
+		IN  : $body 	-> Objet à passer en Body de la requête. On va ensuite le transformer en JSON
+						 	Si $null, on ne passe rien.
 
 		RET : Retour de l'appel
 	#>
-	hidden [Object] callAPI([string]$uri, [string]$method, [string]$json)
+	hidden [Object] callAPI([string]$uri, [string]$method, [PSObject]$body)
 	{
 
 		$args = "--insecure -s --request {0}" -f $method.ToUpper()
 
 		$tmpFile = $null
 
-		if($json -ne "")
+		if($null -ne $body)
 		{
 			# Génération d'un nom de fichier temporaire et ajout du JSON dans celui-ci
 			$tmpFile = $this.getTmpFilename()
-			$json | Out-File -FilePath $tmpFile -Encoding:default
+			(ConvertTo-Json -InputObject $body -Depth 20) | Out-File -FilePath $tmpFile -Encoding:default
 
 			$args += ' --data "@{0}"' -f $tmpFile
 		}

--- a/powershell/include/REST/RESTAPICurl.inc.ps1
+++ b/powershell/include/REST/RESTAPICurl.inc.ps1
@@ -113,7 +113,7 @@ class RESTAPICurl: RESTAPI
 
 		RET : Retour de l'appel
 	#>
-	hidden [Object] callAPI([string]$uri, [string]$method, [PSObject]$body)
+	hidden [Object] callAPI([string]$uri, [string]$method, [System.Object]$body)
 	{
 
 		$args = "--insecure -s --request {0}" -f $method.ToUpper()

--- a/powershell/include/REST/XaaS/Backup/NetBackupAPI.inc.ps1
+++ b/powershell/include/REST/XaaS/Backup/NetBackupAPI.inc.ps1
@@ -64,7 +64,7 @@ class NetBackupAPI: RESTAPICurl
 
 		[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
-		$this.token = ($this.callAPI($uri, "Post", (ConvertTo-Json -InputObject $body -Depth 20))).token
+		$this.token = ($this.callAPI($uri, "Post", $body)).token
 
 		# Mise à jour des headers
 		$this.headers.Add('Authorization', ("{0}" -f $this.token))
@@ -81,7 +81,7 @@ class NetBackupAPI: RESTAPICurl
 	{
 		$uri = "https://{0}/logout" -f $this.server
 
-		$this.callAPI($uri, "Post", "")
+		$this.callAPI($uri, "Post", $null)
     }
     
 
@@ -126,7 +126,7 @@ class NetBackupAPI: RESTAPICurl
 			$uri = "{0} and scheduleType eq '{1}'" -f $uri, $scheduleType
 		}
 
-		return ($this.callAPI($uri, "Get", "")).data
+		return ($this.callAPI($uri, "Get", $null)).data
 	}
 	
 
@@ -152,7 +152,7 @@ class NetBackupAPI: RESTAPICurl
 		$body = $this.loadJSON("xaas-backup-restore-vm.json", $replace)
 
 		# Appel de l'API 
-		return ($this.callAPI($uri, "POST", (ConvertTo-Json -InputObject $body -Depth 20))).data
+		return ($this.callAPI($uri, "POST", $body)).data
 
 	}
 

--- a/powershell/include/REST/XaaS/Backup/NetBackupAPI.inc.ps1
+++ b/powershell/include/REST/XaaS/Backup/NetBackupAPI.inc.ps1
@@ -149,7 +149,7 @@ class NetBackupAPI: RESTAPICurl
 		$replace = @{vmName = $vmName
 					backupId = $backupId}
 
-		$body = $this.loadJSON("xaas-backup-restore-vm.json", $replace)
+		$body = $this.createObjectFromJSON("xaas-backup-restore-vm.json", $replace)
 
 		# Appel de l'API 
 		return ($this.callAPI($uri, "POST", $body)).data

--- a/powershell/include/REST/vRAAPI.inc.ps1
+++ b/powershell/include/REST/vRAAPI.inc.ps1
@@ -318,7 +318,7 @@ class vRAAPI: RESTAPI
 		}
 
 		# Mise à jour des informations
-		$res = $this.callAPI($uri, "Put", $body)
+		$res = $this.callAPI($uri, "Put", $bg)
 		
 		# On recherche l'objet mis à jour
 		return $this.getBG($bg.name)
@@ -347,7 +347,7 @@ class vRAAPI: RESTAPI
 		
 		$bg.extensionData.entries = $entries
 		# Mise à jour des informations
-		$res = $this.callAPI($uri, "Put", $body)
+		$res = $this.callAPI($uri, "Put", $bg)
 
 		# On recherche l'objet mis à jour
 		return $this.getBG($bg.name)
@@ -679,7 +679,7 @@ class vRAAPI: RESTAPI
 		}
 
 		# Mise à jour des informations
-		$res = $this.callAPI($uri, "Put", $body)
+		$res = $this.callAPI($uri, "Put", $ent)
 		
 		# on retourne spécifiquement l'objet qui est dans vRA et pas seulement celui qu'on a utilisé pour faire la mise à jour. Ceci
 		# pour la simple raison que dans certains cas particuliers, on se retrouve avec des erreurs "409 Conflicts" si on essaie de

--- a/powershell/include/REST/vRAAPI.inc.ps1
+++ b/powershell/include/REST/vRAAPI.inc.ps1
@@ -105,7 +105,7 @@ class vRAAPI: RESTAPI
 			$uri = "{0}&{1}" -f $uri, $queryParams
 		}
 
-		return ($this.callAPI($uri, "Get", "")).content
+		return ($this.callAPI($uri, "Get", $null)).content
 	}
 	hidden [Array] getBGListQuery()
 	{
@@ -206,7 +206,7 @@ class vRAAPI: RESTAPI
 		}
 
 		# Création du BG
-		$res = $this.callAPI($uri, "Post", (ConvertTo-Json -InputObject $body -Depth 20))
+		$res = $this.callAPI($uri, "Post", $body)
 		
 		# Recherche et retour du BG
 		# On utilise $body.name et pas simplement $name dans le cas où il y aurait un préfixe ou suffixe de nom déjà hard-codé dans 
@@ -318,7 +318,7 @@ class vRAAPI: RESTAPI
 		}
 
 		# Mise à jour des informations
-		$res = $this.callAPI($uri, "Put", (ConvertTo-Json -InputObject $bg -Depth 20))
+		$res = $this.callAPI($uri, "Put", $body)
 		
 		# On recherche l'objet mis à jour
 		return $this.getBG($bg.name)
@@ -347,7 +347,7 @@ class vRAAPI: RESTAPI
 		
 		$bg.extensionData.entries = $entries
 		# Mise à jour des informations
-		$res = $this.callAPI($uri, "Put", (ConvertTo-Json -InputObject $bg -Depth 20))
+		$res = $this.callAPI($uri, "Put", $body)
 
 		# On recherche l'objet mis à jour
 		return $this.getBG($bg.name)
@@ -366,7 +366,7 @@ class vRAAPI: RESTAPI
 		$uri = "https://{0}/identity/api/tenants/{1}/subtenants/{2}" -f $this.server, $this.tenant, $bgId
 
 		# Mise à jour des informations
-		$res = $this.callAPI($uri, "Delete", "")
+		$res = $this.callAPI($uri, "Delete", $null)
 	}
 
 
@@ -396,7 +396,7 @@ class vRAAPI: RESTAPI
 		$uri = "https://{0}/identity/api/tenants/{1}/subtenants/{2}/roles/{3}/principals/" -f $this.server, $this.tenant, $BGID, $role
 
 		# Récupération de la liste d'objets
-		$res = ($this.callAPI($uri, "Get", "")).content
+		$res = ($this.callAPI($uri, "Get", $null)).content
 		
 		# On remet le tout dans un tableau en récupérant ce qui nous intéresse
 		$resArray = @()
@@ -424,7 +424,7 @@ class vRAAPI: RESTAPI
 			$uri = "https://{0}/identity/api/tenants/{1}/subtenants/{2}/roles/{3}/" -f $this.server, $this.tenant, $BGID, $role
 
 			# Suppression du contenu du rôle
-			$res = $this.callAPI($uri, "Delete", "")
+			$res = $this.callAPI($uri, "Delete", $null)
 		}
 
 	}
@@ -478,7 +478,7 @@ class vRAAPI: RESTAPI
 		)
 
 		# Ajout du rôle
-		$res = $this.callAPI($uri, "Post", (ConvertTo-Json -InputObject $body -Depth 2))
+		$res = $this.callAPI($uri, "Post", $body)
 		
 	}
 
@@ -512,7 +512,7 @@ class vRAAPI: RESTAPI
 		{
 			$uri = "{0}&{1}" -f $uri, $queryParams
 		}
-		return ($this.callAPI($uri, "Get", "")).content
+		return ($this.callAPI($uri, "Get", $null)).content
 
 	}
 	hidden [Array] getEntListQuery()
@@ -620,7 +620,7 @@ class vRAAPI: RESTAPI
 
 		$body = $this.loadJSON("vra-entitlement.json", $replace)
 
-		$res = $this.callAPI($uri, "Post", (ConvertTo-Json -InputObject $body -Depth 20))
+		$res = $this.callAPI($uri, "Post", $body)
 		
 		# Retour de l'entitlement
 		# On utilise $body.name et pas simplement $name dans le cas où il y aurait un préfixe ou suffixe de nom déjà hard-codé dans 
@@ -679,7 +679,7 @@ class vRAAPI: RESTAPI
 		}
 
 		# Mise à jour des informations
-		$res = $this.callAPI($uri, "Put", (ConvertTo-Json -InputObject $ent -Depth 20))
+		$res = $this.callAPI($uri, "Put", $body)
 		
 		# on retourne spécifiquement l'objet qui est dans vRA et pas seulement celui qu'on a utilisé pour faire la mise à jour. Ceci
 		# pour la simple raison que dans certains cas particuliers, on se retrouve avec des erreurs "409 Conflicts" si on essaie de
@@ -722,7 +722,7 @@ class vRAAPI: RESTAPI
 	{
 		$uri = "https://{0}/catalog-service/api/entitlements/{1}" -f $this.server, $entId
 
-		$res = $this.callAPI($uri, "Delete", "")
+		$res = $this.callAPI($uri, "Delete", $null)
 	}
 
 	<#
@@ -752,7 +752,7 @@ class vRAAPI: RESTAPI
 		{
 			$uri = "{0}&{1}" -f $uri, $queryParams
 		}
-		return ($this.callAPI($uri, "Get", "")).content
+		return ($this.callAPI($uri, "Get", $null)).content
 	}
 	hidden [Array] getServiceListQuery()
 	{
@@ -892,7 +892,7 @@ class vRAAPI: RESTAPI
 		{
 			$uri = "{0}&{1}" -f $uri, $queryParams
 		}
-		return ($this.callAPI($uri, "Get", "")).content
+		return ($this.callAPI($uri, "Get", $null)).content
 		
 	}
 	hidden [Array] getResListQuery()
@@ -973,7 +973,7 @@ class vRAAPI: RESTAPI
 		# On l'active (dans le cas où le Template était désactivé)
 		$resTemplate.enabled = $true
 
-		$res = $this.callAPI($uri, "Post", (ConvertTo-Json -InputObject $resTemplate -Depth 20))
+		$res = $this.callAPI($uri, "Post", $resTemplate)
 		
 		return $this.getRes($name)
 
@@ -1010,7 +1010,7 @@ class vRAAPI: RESTAPI
 			$res.extensionData =  $resTemplate.extensionData
 			$res.alertPolicy =  $resTemplate.alertPolicy
 			
-			$res = $this.callAPI($uri, "Put", (ConvertTo-Json -InputObject $res -Depth 20))
+			$res = $this.callAPI($uri, "Put", $res)
 
 			$updated = $true
 		}
@@ -1033,7 +1033,7 @@ class vRAAPI: RESTAPI
 	{
 		$uri = "https://{0}/reservation-service/api/reservations/{1}" -f $this.server, $resID
 
-		$res = $this.callAPI($uri, "Delete", "")
+		$res = $this.callAPI($uri, "Delete", $null)
 		
 	}
 
@@ -1064,7 +1064,7 @@ class vRAAPI: RESTAPI
 		{
 			$uri = "{0}&{1}" -f $uri, $queryParams
 		}
-		return ($this.callAPI($uri, "Get", "")).content
+		return ($this.callAPI($uri, "Get", $null)).content
 		
 	}
 	hidden [Array] getActionListQuery()
@@ -1135,7 +1135,7 @@ class vRAAPI: RESTAPI
 		{
 			$uri = "{0}&{1}" -f $uri, $queryParams
 		}
-		return ($this.callAPI($uri, "Get", "")).content
+		return ($this.callAPI($uri, "Get", $null)).content
 
 	}
 	hidden [Array] getPrincipalsListQuery()
@@ -1211,7 +1211,7 @@ class vRAAPI: RESTAPI
 		{
 			$uri = "{0}&{1}" -f $uri, $queryParams
 		}
-		return ($this.callAPI($uri, "Get", "")).content
+		return ($this.callAPI($uri, "Get", $null)).content
 
 	}
 	hidden [Array] getMachinePrefixListQuery()
@@ -1267,7 +1267,7 @@ class vRAAPI: RESTAPI
 			$uri = "{0}&{1}" -f $uri, $queryParams
 		}
 
-		return ($this.callAPI($uri, "Get", "")).content
+		return ($this.callAPI($uri, "Get", $null)).content
 	}
 
 	<#
@@ -1318,7 +1318,7 @@ class vRAAPI: RESTAPI
 	{
 		$uri = "https://{0}/identity/api/tenants/{1}/directories/{2}/sync" -f $this.server, $this.tenant, $name
 
-		$res = $this.callAPI($uri, "Post", "")
+		$res = $this.callAPI($uri, "Post", $null)
 	}
 
 
@@ -1350,7 +1350,7 @@ class vRAAPI: RESTAPI
 			$uri = "{0}&{1}" -f $uri, $queryParams
 		}
 
-		return ($this.callAPI($uri, "Get", "")).content
+		return ($this.callAPI($uri, "Get", $null)).content
 	}
 	hidden [Array] getApprovePolicyListQuery()
 	{
@@ -1447,7 +1447,7 @@ class vRAAPI: RESTAPI
 		$body = $this.loadJSON($approvalPolicyJSON, $replace)
 
 		# Création de la Policy
-		$res = $this.callAPI($uri, "Post", (ConvertTo-Json -InputObject $body -Depth 20))
+		$res = $this.callAPI($uri, "Post", $body)
 
 		# On utilise $body.name et pas simplement $name dans le cas où il y aurait un préfixe ou suffixe de nom déjà hard-codé dans 
 		# le fichier JSON template
@@ -1497,7 +1497,7 @@ class vRAAPI: RESTAPI
 		}
 
 		# Mise à jour des informations
-		$res = $this.callAPI($uri, "Put", (ConvertTo-Json -InputObject $approvalPolicy -Depth 20))
+		$res = $this.callAPI($uri, "Put", $approvalPolicy)
 
 		# on retourne spécifiquement l'objet qui est dans vRA et pas seulement celui qu'on a utilisé pour faire la mise à jour. Ceci
 		# pour la simple raison que dans certains cas particuliers, on se retrouve avec des erreurs "409 Conflicts" si on essaie de
@@ -1522,7 +1522,7 @@ class vRAAPI: RESTAPI
 		$uri = "https://{0}/approval-service/api/policies/{1}" -f $this.server, $approvalPolicy.id
 
 		# Mise à jour des informations
-		$res = $this.callAPI($uri, "Delete", "")
+		$res = $this.callAPI($uri, "Delete", $null)
 		
 	}
 

--- a/powershell/include/REST/vRAAPI.inc.ps1
+++ b/powershell/include/REST/vRAAPI.inc.ps1
@@ -45,7 +45,7 @@ class vRAAPI: RESTAPI
 						 password = $password
 						 tenant = $tenant}
 
-		$body = $this.loadJSON("vra-user-credentials.json", $replace)
+		$body = $this.createObjectFromJSON("vra-user-credentials.json", $replace)
 
 		$uri = "https://{0}/identity/api/tokens" -f $this.server
 
@@ -195,12 +195,12 @@ class vRAAPI: RESTAPI
 		}
 
 		
-		$body = $this.loadJSON("vra-business-group.json", $replace)
+		$body = $this.createObjectFromJSON("vra-business-group.json", $replace)
 
 		# Ajout des éventuelles custom properties
 		$customProperties.Keys | ForEach-Object {
 
-			$body.extensionData.entries += $this.loadJSON("vra-business-group-extension-data-custom.json", `
+			$body.extensionData.entries += $this.createObjectFromJSON("vra-business-group-extension-data-custom.json", `
 															 			 @{"key" = $_
 															 			  "value" = $customProperties.Item($_)})
 		}
@@ -300,7 +300,7 @@ class vRAAPI: RESTAPI
 				else # Aucune entrée n'a été trouvée
 				{
 					# Ajout des infos avec le template présent dans le fichier JSON
-					$bg.ExtensionData.entries += $this.loadJSON("vra-business-group-extension-data-custom.json", `
+					$bg.ExtensionData.entries += $this.createObjectFromJSON("vra-business-group-extension-data-custom.json", `
 																			@{"key" = $customPropertyKey
 																			"value" = $customProperties.Item($customPropertyKey)})
 				}
@@ -618,7 +618,7 @@ class vRAAPI: RESTAPI
 						 bgID = $BGID
 						 bgName = $bgName}
 
-		$body = $this.loadJSON("vra-entitlement.json", $replace)
+		$body = $this.createObjectFromJSON("vra-entitlement.json", $replace)
 
 		$res = $this.callAPI($uri, "Post", $body)
 		
@@ -796,7 +796,7 @@ class vRAAPI: RESTAPI
 					approvalPolicyId = $approvalPolicy.id}
 
 		# Création du nécessaire pour le service à ajouter
-		$service = $this.loadJSON("vra-entitlement-service.json", $replace)
+		$service = $this.createObjectFromJSON("vra-entitlement-service.json", $replace)
 
 		# Ajout du service à l'objet
 		$ent.entitledServices += $service
@@ -845,7 +845,7 @@ class vRAAPI: RESTAPI
 									approvalPolicyId = $approvalPolicyId}
 
 					# Création du nécessaire pour l'action à ajouter
-					$actionsToAdd += $this.loadJSON("vra-entitlement-action.json", $replace)
+					$actionsToAdd += $this.createObjectFromJSON("vra-entitlement-action.json", $replace)
 				}
 				else # Pas d'infos trouvées pour l'action
 				{
@@ -1425,7 +1425,7 @@ class vRAAPI: RESTAPI
 						 preApprovalLeveNumber = @($levelNo, $true)}
 
 			# Création du level d'approbation et ajout à la liste 
-			$approvalLevels += $this.loadJSON($approvalLevelJSON, $replace)
+			$approvalLevels += $this.createObjectFromJSON($approvalLevelJSON, $replace)
 		}
 
 		# Valeur à mettre pour la configuration du BG
@@ -1444,7 +1444,7 @@ class vRAAPI: RESTAPI
 			}
 		}
 
-		$body = $this.loadJSON($approvalPolicyJSON, $replace)
+		$body = $this.createObjectFromJSON($approvalPolicyJSON, $replace)
 
 		# Création de la Policy
 		$res = $this.callAPI($uri, "Post", $body)

--- a/powershell/include/REST/vSphereAPI.inc.ps1
+++ b/powershell/include/REST/vSphereAPI.inc.ps1
@@ -121,7 +121,7 @@ class vSphereAPI: RESTAPICurl
 					objectType = "VirtualMachine"
 					objectId = $this.extractVMId($vm.id)}
 
-		$body = $this.loadJSON("vsphere-tag-operation.json", $replace)
+		$body = $this.createObjectFromJSON("vsphere-tag-operation.json", $replace)
 
 		$res = $this.callAPI($uri, "Post", $body)
 	}
@@ -169,7 +169,7 @@ class vSphereAPI: RESTAPICurl
 		$replace = @{objectType = "VirtualMachine"
 					objectId = $this.extractVMId($vm.id)}
 
-		$body = $this.loadJSON("vsphere-object-infos.json", $replace)
+		$body = $this.createObjectFromJSON("vsphere-object-infos.json", $replace)
 
 		$tagList = @()
 

--- a/powershell/include/REST/vSphereAPI.inc.ps1
+++ b/powershell/include/REST/vSphereAPI.inc.ps1
@@ -56,7 +56,7 @@ class vSphereAPI: RESTAPICurl
 
 		[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
-		$this.apiSessionId = ($this.callAPI($uri, "Post", "")).value
+		$this.apiSessionId = ($this.callAPI($uri, "Post", $null)).value
 
 		# Mise à jour des headers
 		$this.headers.Add('vmware-api-session-id', $this.apiSessionId)
@@ -73,7 +73,7 @@ class vSphereAPI: RESTAPICurl
 	{
 		$uri = "https://{0}/rest/com/vmware/cis/session" -f $this.server
 
-		$this.callAPI($uri, "Delete", "")
+		$this.callAPI($uri, "Delete", $null)
 	}    
 
 
@@ -101,7 +101,7 @@ class vSphereAPI: RESTAPICurl
 	hidden [PSObject] getTagById([string] $tagId)
 	{
 		$uri = "https://{0}/rest/com/vmware/cis/tagging/tag/id:{1}" -f $this.server, $tagId
-		return ($this.callAPI($uri, "Get", "")).value
+		return ($this.callAPI($uri, "Get", $null)).value
 	}
 
 
@@ -123,7 +123,7 @@ class vSphereAPI: RESTAPICurl
 
 		$body = $this.loadJSON("vsphere-tag-operation.json", $replace)
 
-		$this.callAPI($uri, "Post", (ConvertTo-Json -InputObject $body -Depth 20))
+		$res = $this.callAPI($uri, "Post", $body)
 	}
 
 
@@ -175,7 +175,7 @@ class vSphereAPI: RESTAPICurl
 
 		# On récupère la liste des tags mais on n'a que leurs ID... on boucle donc dessus pour récupérer les informations
 		# de chaque tag et l'ajouter à la liste que l'on va ensuite renvoyer
-		$this.callAPI($uri, "Post", (ConvertTo-Json -InputObject $body -Depth 20)).value | ForEach-Object {
+		$this.callAPI($uri, "Post", $body).value | ForEach-Object {
 
 			$tagList += $this.getTagById($_)
 		}
@@ -192,7 +192,7 @@ class vSphereAPI: RESTAPICurl
 	{
 		$uri = "https://{0}/rest/com/vmware/cis/tagging/tag" -f $this.server
 
-		return $this.callAPI($uri, "Get", "").value
+		return $this.callAPI($uri, "Get", $null).value
 	}
 
 	


### PR DESCRIPTION
Au lieu de passer en paramètre du JSON aux méthodes `callAPI` on passe maintenant l'objet qu'il faudra transformer en JSON ou alors `$null` si pas besoin de passer un body.
Ceci permet de simplifier un peu le code lors de chaque appel.