### PR TITLE
Handle tags by category instead name

### DIFF
--- a/powershell/include/REST/vSphereAPI.inc.ps1
+++ b/powershell/include/REST/vSphereAPI.inc.ps1
@@ -187,7 +187,7 @@ class vSphereAPI: RESTAPICurl
 	#>
 	hidden [PSObject] getCategory([string]$categoryName)
 	{
-		# On récupère la liste des catégories et pour chacun, on recherche les détails pour savoir si le nom correspon
+		# On récupère la liste des catégories et pour chacun, on recherche les détails pour savoir si le nom correspond
 		# et dès qu'on a trouvé, on renvoie l'objet avec les détails.
 		return $this.getCategoryList() | Foreach-Object {
 			$details = $this.getCategoryById($_)


### PR DESCRIPTION
- On ne gère plus les tags de backup via leur nom "NBU-*" mais maintenant via la catégorie à laquelle ils appartiennent. Pourquoi? parce que l'on peut du coup utiliser d'autres tags de la catégorie, qui ont un préfixe différent.
- Ajout de l'interface nécessaire pour interroger les catégories via l'API REST
- Ajout d'un préfix de tag qu'on ne peut pas toucher SURTOUT PAS!! car c'est un tag mis au niveau central, par un opérateur, et il ne faut pas que le client final puisse y toucher.