### PR TITLE
Use var to store script path

### DIFF
--- a/powershell/clean-iso-folders.ps1
+++ b/powershell/clean-iso-folders.ps1
@@ -22,20 +22,24 @@ USAGES:
 #>
 param ( [string]$targetEnv, [string]$targetTenant)
 
+<# On enregistrer l'endroit où le script courant se trouve pour pouvoir effectuer l'import des autres fichiers.
+On fait ceci au lieu d'utiliser $PSScriptRoot car la valeur de ce dernier peut changer si on importe un module (Import-Module) dans
+un des fichiers inclus via ". <pathToFile>" #>
+$SCRIPT_PATH = $PSScriptRoot
 
-. ([IO.Path]::Combine("$PSScriptRoot", "include", "define.inc.ps1"))
-. ([IO.Path]::Combine("$PSScriptRoot", "include", "functions.inc.ps1"))
-. ([IO.Path]::Combine("$PSScriptRoot", "include", "functions-vsphere.inc.ps1"))
-. ([IO.Path]::Combine("$PSScriptRoot", "include", "SecondDayActions.inc.ps1"))
-. ([IO.Path]::Combine("$PSScriptRoot", "include", "Counters.inc.ps1"))
-. ([IO.Path]::Combine("$PSScriptRoot", "include", "LogHistory.inc.ps1"))
-. ([IO.Path]::Combine("$PSScriptRoot", "include", "NameGenerator.inc.ps1"))
-. ([IO.Path]::Combine("$PSScriptRoot", "include", "ConfigReader.inc.ps1"))
+. ([IO.Path]::Combine("$SCRIPT_PATH", "include", "define.inc.ps1"))
+. ([IO.Path]::Combine("$SCRIPT_PATH", "include", "functions.inc.ps1"))
+. ([IO.Path]::Combine("$SCRIPT_PATH", "include", "functions-vsphere.inc.ps1"))
+. ([IO.Path]::Combine("$SCRIPT_PATH", "include", "SecondDayActions.inc.ps1"))
+. ([IO.Path]::Combine("$SCRIPT_PATH", "include", "Counters.inc.ps1"))
+. ([IO.Path]::Combine("$SCRIPT_PATH", "include", "LogHistory.inc.ps1"))
+. ([IO.Path]::Combine("$SCRIPT_PATH", "include", "NameGenerator.inc.ps1"))
+. ([IO.Path]::Combine("$SCRIPT_PATH", "include", "ConfigReader.inc.ps1"))
 
 # Chargement des fichiers pour API REST
-. ([IO.Path]::Combine("$PSScriptRoot", "include", "REST", "APIUtils.inc.ps1"))
-. ([IO.Path]::Combine("$PSScriptRoot", "include", "REST", "RESTAPI.inc.ps1"))
-. ([IO.Path]::Combine("$PSScriptRoot", "include", "REST", "vRAAPI.inc.ps1"))
+. ([IO.Path]::Combine("$SCRIPT_PATH", "include", "REST", "APIUtils.inc.ps1"))
+. ([IO.Path]::Combine("$SCRIPT_PATH", "include", "REST", "RESTAPI.inc.ps1"))
+. ([IO.Path]::Combine("$SCRIPT_PATH", "include", "REST", "vRAAPI.inc.ps1"))
 
 
 # Chargement des fichiers de configuration
@@ -55,10 +59,10 @@ $configGlobal = [ConfigReader]::New("config-global.json")
 try
 {
 	# Création de l'objet pour logguer les exécutions du script (celui-ci sera accédé en variable globale même si c'est pas propre XD)
-	$logHistory =[LogHistory]::new('0.Clean-ISO-Folders', (Join-Path $PSScriptRoot "logs"), 30)
+	$logHistory =[LogHistory]::new('0.Clean-ISO-Folders', (Join-Path $SCRIPT_PATH "logs"), 30)
 
 	# On contrôle le prototype d'appel du script
-	. ([IO.Path]::Combine("$PSScriptRoot", "include", "ArgsPrototypeChecker.inc.ps1"))
+	. ([IO.Path]::Combine("$SCRIPT_PATH", "include", "ArgsPrototypeChecker.inc.ps1"))
 
 
 	$logHistory.addLineAndDisplay(("Executed with parameters: Environment={0}, Tenant={1}" -f $targetEnv, $targetTenant))

--- a/powershell/sync-ad-groups-from-ldap-or-django.ps1
+++ b/powershell/sync-ad-groups-from-ldap-or-django.ps1
@@ -24,22 +24,27 @@ USAGES:
 #>
 param ( [string]$targetEnv, [string]$targetTenant)
 
-. ([IO.Path]::Combine("$PSScriptRoot", "include", "define.inc.ps1"))
-. ([IO.Path]::Combine("$PSScriptRoot", "include", "define-mysql.inc.ps1"))
-. ([IO.Path]::Combine("$PSScriptRoot", "include", "functions.inc.ps1"))
-. ([IO.Path]::Combine("$PSScriptRoot", "include", "EPFLLDAP.inc.ps1"))
-. ([IO.Path]::Combine("$PSScriptRoot", "include", "Counters.inc.ps1"))
-. ([IO.Path]::Combine("$PSScriptRoot", "include", "LogHistory.inc.ps1"))
-. ([IO.Path]::Combine("$PSScriptRoot", "include", "NameGenerator.inc.ps1"))
-. ([IO.Path]::Combine("$PSScriptRoot", "include", "SecondDayActions.inc.ps1"))
-. ([IO.Path]::Combine("$PSScriptRoot", "include", "MySQL.inc.ps1"))
-. ([IO.Path]::Combine("$PSScriptRoot", "include", "DjangoMySQL.inc.ps1"))
-. ([IO.Path]::Combine("$PSScriptRoot", "include", "ConfigReader.inc.ps1"))
+<# On enregistrer l'endroit où le script courant se trouve pour pouvoir effectuer l'import des autres fichiers.
+On fait ceci au lieu d'utiliser $PSScriptRoot car la valeur de ce dernier peut changer si on importe un module (Import-Module) dans
+un des fichiers inclus via ". <pathToFile>" #>
+$SCRIPT_PATH = $PSScriptRoot
+
+. ([IO.Path]::Combine("$SCRIPT_PATH", "include", "define.inc.ps1"))
+. ([IO.Path]::Combine("$SCRIPT_PATH", "include", "define-mysql.inc.ps1"))
+. ([IO.Path]::Combine("$SCRIPT_PATH", "include", "functions.inc.ps1"))
+. ([IO.Path]::Combine("$SCRIPT_PATH", "include", "EPFLLDAP.inc.ps1"))
+. ([IO.Path]::Combine("$SCRIPT_PATH", "include", "Counters.inc.ps1"))
+. ([IO.Path]::Combine("$SCRIPT_PATH", "include", "LogHistory.inc.ps1"))
+. ([IO.Path]::Combine("$SCRIPT_PATH", "include", "NameGenerator.inc.ps1"))
+. ([IO.Path]::Combine("$SCRIPT_PATH", "include", "SecondDayActions.inc.ps1"))
+. ([IO.Path]::Combine("$SCRIPT_PATH", "include", "MySQL.inc.ps1"))
+. ([IO.Path]::Combine("$SCRIPT_PATH", "include", "DjangoMySQL.inc.ps1"))
+. ([IO.Path]::Combine("$SCRIPT_PATH", "include", "ConfigReader.inc.ps1"))
 
 # Chargement des fichiers pour API REST
-. ([IO.Path]::Combine("$PSScriptRoot", "include", "REST", "APIUtils.inc.ps1"))
-. ([IO.Path]::Combine("$PSScriptRoot", "include", "REST", "RESTAPI.inc.ps1"))
-. ([IO.Path]::Combine("$PSScriptRoot", "include", "REST", "vRAAPI.inc.ps1"))
+. ([IO.Path]::Combine("$SCRIPT_PATH", "include", "REST", "APIUtils.inc.ps1"))
+. ([IO.Path]::Combine("$SCRIPT_PATH", "include", "REST", "RESTAPI.inc.ps1"))
+. ([IO.Path]::Combine("$SCRIPT_PATH", "include", "REST", "vRAAPI.inc.ps1"))
 
 # Chargement des fichiers de configuration
 $configVra = [ConfigReader]::New("config-vra.json")
@@ -213,13 +218,13 @@ $EPFL_FAC_UNIT_NB_LEVEL = 3
 # aucune écriture. 
 # Pour passer en mode simulation, il suffit de créer un fichier "SIMULATION_MODE" au même niveau que
 # le script courant
-$SIMULATION_MODE = (Test-Path -Path ([IO.Path]::Combine("$PSScriptRoot", $global:SCRIPT_ACTION_FILE__SIMULATION_MODE)))
+$SIMULATION_MODE = (Test-Path -Path ([IO.Path]::Combine("$SCRIPT_PATH", $global:SCRIPT_ACTION_FILE__SIMULATION_MODE)))
 
 # Pour dire si on est en mode test. Si c'est le cas, on ne traitera qu'un nombre limité d'unités, nombre qui est
 # spécifié par $EPFL_TEST_NB_UNITS_MAX ci-dessous (si Tenant EPFL).
 # Pour passer en mode simulation, il suffit de créer un fichier "TEST_MODE" au même niveau que
 # le script courant
-$TEST_MODE = (Test-Path -Path ([IO.Path]::Combine("$PSScriptRoot", $global:SCRIPT_ACTION_FILE__TEST_MODE)))
+$TEST_MODE = (Test-Path -Path ([IO.Path]::Combine("$SCRIPT_PATH", $global:SCRIPT_ACTION_FILE__TEST_MODE)))
 $EPFL_TEST_NB_UNITS_MAX = 10
 
 
@@ -230,10 +235,10 @@ $EPFL_TEST_NB_UNITS_MAX = 10
 try
 {
 	# Création de l'objet pour logguer les exécutions du script (celui-ci sera accédé en variable globale même si c'est pas propre XD)
-	$logHistory = [LogHistory]::new('1.sync-AD-from-LDAP', (Join-Path $PSScriptRoot "logs"), 30)
+	$logHistory = [LogHistory]::new('1.sync-AD-from-LDAP', (Join-Path $SCRIPT_PATH "logs"), 30)
 
 	# On contrôle le prototype d'appel du script
-	. ([IO.Path]::Combine("$PSScriptRoot", "include", "ArgsPrototypeChecker.inc.ps1"))
+	. ([IO.Path]::Combine("$SCRIPT_PATH", "include", "ArgsPrototypeChecker.inc.ps1"))
 
 	$logHistory.addLineAndDisplay(("Executed with parameters: Environment={0}, Tenant={1}" -f $targetEnv, $targetTenant))
 

--- a/powershell/sync-bg-from-ad.ps1
+++ b/powershell/sync-bg-from-ad.ps1
@@ -51,24 +51,28 @@ USAGES:
 #>
 param ( [string]$targetEnv, [string]$targetTenant)
 
+<# On enregistrer l'endroit où le script courant se trouve pour pouvoir effectuer l'import des autres fichiers.
+On fait ceci au lieu d'utiliser $PSScriptRoot car la valeur de ce dernier peut changer si on importe un module (Import-Module) dans
+un des fichiers inclus via ". <pathToFile>" #>
+$SCRIPT_PATH = $PSScriptRoot
 
-. ([IO.Path]::Combine("$PSScriptRoot", "include", "define.inc.ps1"))
-. ([IO.Path]::Combine("$PSScriptRoot", "include", "functions.inc.ps1"))
-. ([IO.Path]::Combine("$PSScriptRoot", "include", "JSONUtils.inc.ps1"))
-. ([IO.Path]::Combine("$PSScriptRoot", "include", "NewItems.inc.ps1"))
-. ([IO.Path]::Combine("$PSScriptRoot", "include", "SecondDayActions.inc.ps1"))
-. ([IO.Path]::Combine("$PSScriptRoot", "include", "Counters.inc.ps1"))
-. ([IO.Path]::Combine("$PSScriptRoot", "include", "LogHistory.inc.ps1"))
-. ([IO.Path]::Combine("$PSScriptRoot", "include", "NameGenerator.inc.ps1"))
-. ([IO.Path]::Combine("$PSScriptRoot", "include", "ConfigReader.inc.ps1"))
+. ([IO.Path]::Combine("$SCRIPT_PATH", "include", "define.inc.ps1"))
+. ([IO.Path]::Combine("$SCRIPT_PATH", "include", "functions.inc.ps1"))
+. ([IO.Path]::Combine("$SCRIPT_PATH", "include", "JSONUtils.inc.ps1"))
+. ([IO.Path]::Combine("$SCRIPT_PATH", "include", "NewItems.inc.ps1"))
+. ([IO.Path]::Combine("$SCRIPT_PATH", "include", "SecondDayActions.inc.ps1"))
+. ([IO.Path]::Combine("$SCRIPT_PATH", "include", "Counters.inc.ps1"))
+. ([IO.Path]::Combine("$SCRIPT_PATH", "include", "LogHistory.inc.ps1"))
+. ([IO.Path]::Combine("$SCRIPT_PATH", "include", "NameGenerator.inc.ps1"))
+. ([IO.Path]::Combine("$SCRIPT_PATH", "include", "ConfigReader.inc.ps1"))
 
 # Chargement des fichiers pour API REST
-. ([IO.Path]::Combine("$PSScriptRoot", "include", "REST", "APIUtils.inc.ps1"))
-. ([IO.Path]::Combine("$PSScriptRoot", "include", "REST", "RESTAPI.inc.ps1"))
-. ([IO.Path]::Combine("$PSScriptRoot", "include", "REST", "RESTAPICurl.inc.ps1"))
-. ([IO.Path]::Combine("$PSScriptRoot", "include", "REST", "vRAAPI.inc.ps1"))
-. ([IO.Path]::Combine("$PSScriptRoot", "include", "REST", "vROAPI.inc.ps1"))
-. ([IO.Path]::Combine("$PSScriptRoot", "include", "REST", "NSXAPI.inc.ps1"))
+. ([IO.Path]::Combine("$SCRIPT_PATH", "include", "REST", "APIUtils.inc.ps1"))
+. ([IO.Path]::Combine("$SCRIPT_PATH", "include", "REST", "RESTAPI.inc.ps1"))
+. ([IO.Path]::Combine("$SCRIPT_PATH", "include", "REST", "RESTAPICurl.inc.ps1"))
+. ([IO.Path]::Combine("$SCRIPT_PATH", "include", "REST", "vRAAPI.inc.ps1"))
+. ([IO.Path]::Combine("$SCRIPT_PATH", "include", "REST", "vROAPI.inc.ps1"))
+. ([IO.Path]::Combine("$SCRIPT_PATH", "include", "REST", "NSXAPI.inc.ps1"))
 
 
 
@@ -167,7 +171,7 @@ function createApprovalPolicyIfNotExists([vRAAPI]$vra, [string]$name, [string]$d
 	# Si l'approval policy existe, qu'elle n'a pas encore été traitée et qu'il est demandé de les recréer 
 	if(($null -ne $approvePolicy) -and `
 		($processedApprovalPoliciesIDs.value -notcontains $approvePolicy.id) -and `
-		(Test-Path -Path ([IO.Path]::Combine("$PSScriptRoot", $global:SCRIPT_ACTION_FILE__RECREATE_APPROVAL_POLICIES))))
+		(Test-Path -Path ([IO.Path]::Combine("$SCRIPT_PATH", $global:SCRIPT_ACTION_FILE__RECREATE_APPROVAL_POLICIES))))
 	{
 		$logHistory.addLineAndDisplay(("-> Approval Policy '{0}' already exists but recreation asked. Deleting it..." -f $fullName))
 
@@ -1249,10 +1253,10 @@ function createFirewallSectionRulesIfNotExists
 try
 {
 	# Création de l'objet pour logguer les exécutions du script (celui-ci sera accédé en variable globale même si c'est pas propre XD)
-	$logHistory =[LogHistory]::new('2.sync-BG-from-AD', (Join-Path $PSScriptRoot "logs"), 30)
+	$logHistory =[LogHistory]::new('2.sync-BG-from-AD', (Join-Path $SCRIPT_PATH "logs"), 30)
 
 	# On contrôle le prototype d'appel du script
-	. ([IO.Path]::Combine("$PSScriptRoot", "include", "ArgsPrototypeChecker.inc.ps1"))
+	. ([IO.Path]::Combine("$SCRIPT_PATH", "include", "ArgsPrototypeChecker.inc.ps1"))
 
 	# Création de l'objet qui permettra de générer les noms des groupes AD et "groups"
 	$nameGenerator = [NameGenerator]::new($targetEnv, $targetTenant)
@@ -1725,7 +1729,7 @@ try
 
 	# Si le fichier qui demandait à ce que l'on force la recréation des policies existe, on le supprime, afin d'éviter 
 	# que le script ne s'exécute à nouveau en recréant les approval policies, ce qui ne serait pas très bien...
-	$recreatePoliciesFile = ([IO.Path]::Combine("$PSScriptRoot", $global:SCRIPT_ACTION_FILE__RECREATE_APPROVAL_POLICIES))
+	$recreatePoliciesFile = ([IO.Path]::Combine("$SCRIPT_PATH", $global:SCRIPT_ACTION_FILE__RECREATE_APPROVAL_POLICIES))
 	if(Test-Path -Path $recreatePoliciesFile)
 	{
 		Remove-Item -Path $recreatePoliciesFile

--- a/powershell/vsphere-update-vm-notes-with-tools-version.ps1
+++ b/powershell/vsphere-update-vm-notes-with-tools-version.ps1
@@ -19,15 +19,19 @@ USAGES:
 
 param ( [string]$targetEnv)
 
+<# On enregistrer l'endroit où le script courant se trouve pour pouvoir effectuer l'import des autres fichiers.
+On fait ceci au lieu d'utiliser $PSScriptRoot car la valeur de ce dernier peut changer si on importe un module (Import-Module) dans
+un des fichiers inclus via ". <pathToFile>" #>
+$SCRIPT_PATH = $PSScriptRoot
 
 # Inclusion des fichiers nécessaires (génériques)
-. ([IO.Path]::Combine("$PSScriptRoot", "include", "define.inc.ps1"))
-. ([IO.Path]::Combine("$PSScriptRoot", "include", "functions.inc.ps1"))
-. ([IO.Path]::Combine("$PSScriptRoot", "include", "Counters.inc.ps1"))
-. ([IO.Path]::Combine("$PSScriptRoot", "include", "LogHistory.inc.ps1"))
-. ([IO.Path]::Combine("$PSScriptRoot", "include", "ConfigReader.inc.ps1"))
+. ([IO.Path]::Combine("$SCRIPT_PATH", "include", "define.inc.ps1"))
+. ([IO.Path]::Combine("$SCRIPT_PATH", "include", "functions.inc.ps1"))
+. ([IO.Path]::Combine("$SCRIPT_PATH", "include", "Counters.inc.ps1"))
+. ([IO.Path]::Combine("$SCRIPT_PATH", "include", "LogHistory.inc.ps1"))
+. ([IO.Path]::Combine("$SCRIPT_PATH", "include", "ConfigReader.inc.ps1"))
 # Fichiers propres au script courant 
-. ([IO.Path]::Combine("$PSScriptRoot", "include", "functions-vsphere.inc.ps1"))
+. ([IO.Path]::Combine("$SCRIPT_PATH", "include", "functions-vsphere.inc.ps1"))
 
 
 # Chargement des fichiers de configuration
@@ -80,10 +84,10 @@ try
 {
 
     # Création de l'objet pour logguer les exécutions du script (celui-ci sera accédé en variable globale même si c'est pas propre XD)
-    $logHistory = [LogHistory]::new('vsphere-update-VM-notes-with-Tools-version', (Join-Path $PSScriptRoot "logs"), 30)
+    $logHistory = [LogHistory]::new('vsphere-update-VM-notes-with-Tools-version', (Join-Path $SCRIPT_PATH "logs"), 30)
     
     # On commence par contrôler le prototype d'appel du script
-    . ([IO.Path]::Combine("$PSScriptRoot", "include", "ArgsPrototypeChecker.inc.ps1"))
+    . ([IO.Path]::Combine("$SCRIPT_PATH", "include", "ArgsPrototypeChecker.inc.ps1"))
 
 	# Création d'un objet pour gérer les compteurs (celui-ci sera accédé en variable globale même si c'est pas propre XD)
 	$counters = [Counters]::new()

--- a/powershell/xaas-backup-endpoints.ps1
+++ b/powershell/xaas-backup-endpoints.ps1
@@ -40,24 +40,27 @@ USAGES:
 #>
 param ( [string]$targetEnv, [string]$action, [string]$vmName, [string]$backupTag, [string]$restoreBackupId, [string]$restoreTimestamp)
 
-
+<# On enregistrer l'endroit où le script courant se trouve pour pouvoir effectuer l'import des autres fichiers.
+On fait ceci au lieu d'utiliser $PSScriptRoot car la valeur de ce dernier peut changer si on importe un module (Import-Module) dans
+un des fichiers inclus via ". <pathToFile>" #>
+$SCRIPT_PATH = $PSScriptRoot
 
 # Inclusion des fichiers nécessaires (génériques)
-. ([IO.Path]::Combine("$PSScriptRoot", "include", "define.inc.ps1"))
-. ([IO.Path]::Combine("$PSScriptRoot", "include", "functions.inc.ps1"))
-. ([IO.Path]::Combine("$PSScriptRoot", "include", "LogHistory.inc.ps1"))
-. ([IO.Path]::Combine("$PSScriptRoot", "include", "ConfigReader.inc.ps1"))
+. ([IO.Path]::Combine("$SCRIPT_PATH", "include", "define.inc.ps1"))
+. ([IO.Path]::Combine("$SCRIPT_PATH", "include", "functions.inc.ps1"))
+. ([IO.Path]::Combine("$SCRIPT_PATH", "include", "LogHistory.inc.ps1"))
+. ([IO.Path]::Combine("$SCRIPT_PATH", "include", "ConfigReader.inc.ps1"))
 
 # Fichiers propres au script courant 
-. ([IO.Path]::Combine("$PSScriptRoot", "include", "functions-vsphere.inc.ps1"))
-. ([IO.Path]::Combine("$PSScriptRoot", "include", "XaaS", "functions.inc.ps1"))
+. ([IO.Path]::Combine("$SCRIPT_PATH", "include", "functions-vsphere.inc.ps1"))
+. ([IO.Path]::Combine("$SCRIPT_PATH", "include", "XaaS", "functions.inc.ps1"))
 
 # Chargement des fichiers pour API REST
-. ([IO.Path]::Combine("$PSScriptRoot", "include", "REST", "APIUtils.inc.ps1"))
-. ([IO.Path]::Combine("$PSScriptRoot", "include", "REST", "RESTAPI.inc.ps1"))
-. ([IO.Path]::Combine("$PSScriptRoot", "include", "REST", "RESTAPICurl.inc.ps1"))
-. ([IO.Path]::Combine("$PSScriptRoot", "include", "REST", "vSphereAPI.inc.ps1"))
-. ([IO.Path]::Combine("$PSScriptRoot", "include", "REST", "XaaS", "Backup", "NetBackupAPI.inc.ps1"))
+. ([IO.Path]::Combine("$SCRIPT_PATH", "include", "REST", "APIUtils.inc.ps1"))
+. ([IO.Path]::Combine("$SCRIPT_PATH", "include", "REST", "RESTAPI.inc.ps1"))
+. ([IO.Path]::Combine("$SCRIPT_PATH", "include", "REST", "RESTAPICurl.inc.ps1"))
+. ([IO.Path]::Combine("$SCRIPT_PATH", "include", "REST", "vSphereAPI.inc.ps1"))
+. ([IO.Path]::Combine("$SCRIPT_PATH", "include", "REST", "XaaS", "Backup", "NetBackupAPI.inc.ps1"))
 
 
 # Chargement des fichiers de configuration
@@ -94,10 +97,10 @@ try
     $output = getObjectForOutput
 
     # Création de l'objet pour logguer les exécutions du script (celui-ci sera accédé en variable globale même si c'est pas propre XD)
-    $logHistory = [LogHistory]::new('xaas-backup', (Join-Path $PSScriptRoot "logs"), 30)
+    $logHistory = [LogHistory]::new('xaas-backup', (Join-Path $SCRIPT_PATH "logs"), 30)
 
     # On commence par contrôler le prototype d'appel du script
-    . ([IO.Path]::Combine("$PSScriptRoot", "include", "ArgsPrototypeChecker.inc.ps1"))
+    . ([IO.Path]::Combine("$SCRIPT_PATH", "include", "ArgsPrototypeChecker.inc.ps1"))
    
 
     # -------------------------------------------------------------------------------------------


### PR DESCRIPTION
Utilisation d'une variable pour enregistrer `$PSScriptRoot` car la valeur peut changer si on fait un `Import-Module` depuis un fichier qui est inclus (`. <pathToFile>`) dans le script racine... 
On utilise donc cette autre variable dans le reste du script pour faire les inclusions.