### PR TITLE
Load module in main script

### DIFF
--- a/powershell/include/REST/XaaS/S3/ScalityAPI.inc.ps1
+++ b/powershell/include/REST/XaaS/S3/ScalityAPI.inc.ps1
@@ -21,8 +21,14 @@
    DATE   : Mai 2019    
 #>
 
-# Chargement du module PowerShell
-Import-Module AWSPowerShell
+<# On regarde si le module PowerShell est chargé. S'il ne l'est pas, on propage une erreur. 
+Le module doit être chargé dans le script principal et pas dans ce fichier. Si on le fait ailleurs, le
+contenu de la variable $PSScriptRoot est modifiée avec le chemin jusqu'au dossier où on a fait le 
+Import-Module... ce qui peut avoir des effets de bords indésirables... #>
+if( $null -eq (Get-Module | Where-Object {$_.Name -eq "AWSPowerShell"}) )
+{
+    Throw "Please load AWSPowerShell module (Import-Module) in main script before including this file."
+}
 
 $global:XAAS_S3_STATEMENT_KEYWORD = "s3:Get*"
 

--- a/powershell/xaas-s3-endpoint.ps1
+++ b/powershell/xaas-s3-endpoint.ps1
@@ -47,30 +47,28 @@ USAGES:
 #>
 param([string]$targetEnv, [string]$targetTenant, [string]$action, [string]$unitOrSvcID, [string]$friendlyName, [string]$linkedTo, [string]$bucketName, [string]$userType, [string]$enabled, [switch]$status)
 
-<# On enregistrer l'endroit où le script courant se trouve pour pouvoir effectuer l'import des autres fichiers.
-On fait ceci au lieu d'utiliser $PSScriptRoot car la valeur de ce dernier peut changer si on importe un module (Import-Module) dans
-un des fichiers inclus via ". <pathToFile>" #>
-$SCRIPT_PATH = $PSScriptRoot
+# Chargement du module PowerShell
+Import-Module AWSPowerShell
 
 # Inclusion des fichiers nécessaires (génériques)
-. ([IO.Path]::Combine("$SCRIPT_PATH", "include", "define.inc.ps1"))
-. ([IO.Path]::Combine("$SCRIPT_PATH", "include", "functions.inc.ps1"))
-. ([IO.Path]::Combine("$SCRIPT_PATH", "include", "LogHistory.inc.ps1"))
-. ([IO.Path]::Combine("$SCRIPT_PATH", "include", "ConfigReader.inc.ps1"))
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "define.inc.ps1"))
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "functions.inc.ps1"))
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "LogHistory.inc.ps1"))
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "ConfigReader.inc.ps1"))
 
 # Fichiers propres au script courant 
-. ([IO.Path]::Combine("$SCRIPT_PATH", "include", "XaaS", "functions.inc.ps1"))
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "XaaS", "functions.inc.ps1"))
 
 # Chargement des fichiers pour API REST
-. ([IO.Path]::Combine("$SCRIPT_PATH", "include", "REST", "APIUtils.inc.ps1"))
-. ([IO.Path]::Combine("$SCRIPT_PATH", "include", "REST", "RESTAPI.inc.ps1"))
-. ([IO.Path]::Combine("$SCRIPT_PATH", "include", "REST", "RESTAPICurl.inc.ps1"))
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "REST", "APIUtils.inc.ps1"))
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "REST", "RESTAPI.inc.ps1"))
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "REST", "RESTAPICurl.inc.ps1"))
 
 # Chargement des fichiers propres à XaaS S3
-. ([IO.Path]::Combine("$SCRIPT_PATH", "include", "XaaS", "S3", "define.inc.ps1"))
-. ([IO.Path]::Combine("$SCRIPT_PATH", "include", "XaaS", "S3", "NameGeneratorS3.inc.ps1"))
-. ([IO.Path]::Combine("$SCRIPT_PATH", "include", "REST", "XaaS", "S3", "ScalityWebConsoleAPI.inc.ps1"))
-. ([IO.Path]::Combine("$SCRIPT_PATH", "include", "REST", "XaaS", "S3", "ScalityAPI.inc.ps1"))
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "XaaS", "S3", "define.inc.ps1"))
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "XaaS", "S3", "NameGeneratorS3.inc.ps1"))
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "REST", "XaaS", "S3", "ScalityWebConsoleAPI.inc.ps1"))
+. ([IO.Path]::Combine("$PSScriptRoot", "include", "REST", "XaaS", "S3", "ScalityAPI.inc.ps1"))
 
 
 # Chargement des fichiers de configuration
@@ -100,10 +98,10 @@ try
     $output = getObjectForOutput
 
     # Création de l'objet pour logguer les exécutions du script (celui-ci sera accédé en variable globale même si c'est pas propre XD)
-    $logHistory = [LogHistory]::new('xaas-s3', (Join-Path $SCRIPT_PATH "logs"), 30)
+    $logHistory = [LogHistory]::new('xaas-s3', (Join-Path $PSScriptRoot "logs"), 30)
     
     # On commence par contrôler le prototype d'appel du script
-    . ([IO.Path]::Combine("$SCRIPT_PATH", "include", "ArgsPrototypeChecker.inc.ps1"))
+    . ([IO.Path]::Combine("$PSScriptRoot", "include", "ArgsPrototypeChecker.inc.ps1"))
 
     # Ajout d'informations dans le log
     $logHistory.addLine("Script executed with following parameters: `n{0}" -f ($PsBoundParameters | ConvertTo-Json))


### PR DESCRIPTION
Si on fait un `Import-Module` depuis un fichier qui est inclus (`. <pathToIncludedFile>`) dans le script racine, le contenu de `$PSScriptRoot` change pour avoir le chemin jusqu'au fichier dans lequel on a effectué le `Import-Module`... 
Changement de la manière de faire pour `ScalityAPI` et on fait juste un check que le module soit bien chargé à l'exécution du fichier (inclusion) et si ce n'est pas le cas, on lève une exception disant qu'il faut d'abord faire un `Import-Module` dans le script principal. 