### PR TITLE
Some S3 updates

### DIFF
--- a/powershell/include/REST/XaaS/S3/ScalityAPI.inc.ps1
+++ b/powershell/include/REST/XaaS/S3/ScalityAPI.inc.ps1
@@ -127,6 +127,19 @@ class ScalityAPI: APIUtils
 
     <#
 	-------------------------------------------------------------------------------------
+        BUT : Renvoie la liste des buckets
+
+        RET : la liste des buckets
+	#>
+    [PSObject] getBucketList()
+    {
+        # Documentation: https://docs.aws.amazon.com/ja_jp/powershell/latest/reference/items/Get-S3Bucket.html
+        return Get-S3Bucket -EndpointUrl $this.s3EndpointUrl -Credential $this.credentials 
+    }
+
+
+    <#
+	-------------------------------------------------------------------------------------
         BUT : Permet de savoir si un bucket existe
         
         IN  : $bucketName   -> Le nom du bucket        
@@ -771,6 +784,31 @@ class ScalityAPI: APIUtils
             Unregister-IAMUserPolicy -EndpointUrl $this.s3EndpointUrl -Credential $this.credentials `
                                         -UserName $username -PolicyArn $policy.Arn 
         }
-    }    
+    } 
+    
+    
+    <#
+    -------------------------------------------------------------------------------------
+    -------------------------------------------------------------------------------------
+                                        OBJECTS 
+    -------------------------------------------------------------------------------------
+    -------------------------------------------------------------------------------------
+    #>
+
+
+    <#
+	-------------------------------------------------------------------------------------
+        BUT : Renvoie la liste des objets d'un bucket
+        
+        IN  : $bucketName   -> Le nom du bucket        
+
+        RET : Liste des objets
+	#>
+    [PSObject] getBucketObjectList([string]$bucketName)
+    {
+        # https://docs.aws.amazon.com/ja_jp/powershell/latest/reference/items/Get-S3Object.html
+        return Get-S3Object -EndpointUrl $this.s3EndpointUrl -Credential $this.credentials `
+                             -BucketName $bucketName
+    }
 
 }

--- a/powershell/include/XaaS/S3/NameGeneratorS3.inc.ps1
+++ b/powershell/include/XaaS/S3/NameGeneratorS3.inc.ps1
@@ -64,7 +64,7 @@ class NameGeneratorS3
          Throw "Unknown access type ({0})" -f $accessType
       }
 
-      return "{0}-{1}-{2}-{3}" -f $this.unitOrSvcID, $this.hash, $userOrPol.ToLower(), $accessType.ToLower()
+      return ("{0}-{1}-{2}-{3}" -f $this.unitOrSvcID, $this.hash, $userOrPol, $accessType).ToLower()
    }
 
 


### PR DESCRIPTION
- On utilise des noms de Policy, Users et Bucket 100% en minuscule. Normalement il n'y a que les buckets qui n'acceptent pas les majuscules mais comme ça on est alignés.
- Ajout des commandes suivantes au script:
  - `bucketExists`
  - `bucketIsEmpty`
  - `getBuckets` (c'est con, j'aurais voulu mettre `bucketList` mais y'avait déjà un `getUsers` donc... fallait rester aligné).