### PR TITLE
XaaS sync tags handle not in vsphere

### DIFF
--- a/powershell/include/REST/vSphereAPI.inc.ps1
+++ b/powershell/include/REST/vSphereAPI.inc.ps1
@@ -227,6 +227,20 @@ class vSphereAPI: RESTAPICurl
 
 	<#
 		-------------------------------------------------------------------------------------
+        BUT : Permet de savoir si une VM existe
+        
+		IN  : $vmName	-> Nom de la VM
+
+		RET : $true|$false
+	#>
+	[bool] VMExists([string]$vmName)
+	{
+		return ($null -ne $this.getVM($vmName))
+	}
+
+
+	<#
+		-------------------------------------------------------------------------------------
 		BUT : Renvoie la liste des tags (détaillés) attachés à l'objet représentant une VM qui 
 				est passé en paramètre. Cet objet aura été obtenu via le CmdLet "Get-VM"
         
@@ -242,6 +256,21 @@ class vSphereAPI: RESTAPICurl
 		{
 			Throw ("VM {0} not found in vSphere" -f $vmName)
 		}
+
+		return $this.getVMTags($vm)
+	}
+
+		<#
+		-------------------------------------------------------------------------------------
+		BUT : Renvoie la liste des tags (détaillés) attachés à l'objet représentant une VM qui 
+				est passé en paramètre. Cet objet aura été obtenu via le CmdLet "Get-VM"
+        
+        IN  : $vmName	-> Nom de la VM
+
+		RET : Tableau avec les détails des tags 
+	#>
+    [Array] getVMTags([psobject] $vm)
+    {
 
 		$uri = "https://{0}/rest/com/vmware/cis/tagging/tag-association?~action=list-attached-tags" -f $this.server
 
@@ -261,8 +290,7 @@ class vSphereAPI: RESTAPICurl
 
 		return $tagList
 	}
-
-
+	
 	<#
 		-------------------------------------------------------------------------------------
 		BUT : Renvoie la liste des tags (détaillés) attachés à l'objet représentant une VM qui 

--- a/powershell/xaas-backup-sync-vm-tags.ps1
+++ b/powershell/xaas-backup-sync-vm-tags.ps1
@@ -99,6 +99,7 @@ try
     $counters.add('UpdatedTags', '# VM Updated tags')
     $counters.add('CorrectTags', '# VM Correct tags')
     $counters.add('ProcessedVM', '# VM Processed')
+    $counters.add('VMNotInvSphere', '# VM not in vSphere')
 
     # -------------------------------------------------------------------------------------------
 
@@ -140,6 +141,14 @@ try
             if($null -ne $vRATag)
             {
                 $logHistory.addLineAndDisplay("--> Backup tag found! -> {0}" -f (backupTagRepresentation -backupTag $vRATag))
+
+                # Si on ne trouve pas la VM dans vSphere, 
+                if(! $vsphereApi.VMExists($vmName))
+                {
+                    $logHistory.addLineAndDisplay("--> VM doesn't exists in vSphere !!")
+                    $counters.inc('VMNotInvSphere')
+                    continue
+                }
 
                 # Recherche du tag attribué à la VM 
                 $vmTag = $vsphereApi.getVMTags($vmName, $NBU_TAG_CATEGORY)


### PR DESCRIPTION
Si une VM présente dans vRA ne l'était pas dans vSphere, le script part en erreur car une exception est levée. Changement de ceci pour gérer le fait qu'une VM ne se trouve pas dans vSphere et utilisation d'un compteur pour garder la trace de ça.

