### PR TITLE
XaaS Backup Tag sync reverse (vSphere -> vRA)

### DIFF
--- a/powershell/include/REST/vRAAPI.inc.ps1
+++ b/powershell/include/REST/vRAAPI.inc.ps1
@@ -1532,6 +1532,138 @@ class vRAAPI: RESTAPI
 		
 	}
 
+	<#
+		-------------------------------------------------------------------------------------
+		-------------------------------------------------------------------------------------
+									Resource actions
+		-------------------------------------------------------------------------------------
+		-------------------------------------------------------------------------------------
+	#>
+
+	<#
+		-------------------------------------------------------------------------------------
+		BUT : Renvoie la liste des actions disponibles pour une ressource donnée
+
+		IN  : $forResource -> Objet représentant la ressource dont on veut la liste des actions.
+		
+		RET : Tableau avec la liste des actions
+	#>
+	[Array] getResourceActionList([PSCustomObject]$forResource)
+	{
+		
+		$uri = "https://{0}/catalog-service/api/consumer/resources/{1}/actions" -f $this.server, $forResource.id
+
+		# Retour de la liste
+		return $this.callAPI($uri, "Get", $null).content
+	}
+
+
+	<#
+		-------------------------------------------------------------------------------------
+		BUT : Renvoie une action donnée par son nom pour la ressource passée
+
+		IN  : $forResource 	-> Objet représentant la ressource 
+		IN  : $actionName	-> Nom de l'action
+		
+		RET : Objet contenant l'action
+				$null si pas trouvée
+	#>
+	[PSCustomObject] getResourceActionInfos([PSCustomObject]$forResource, [String]$actionName)
+	{
+		# Recherche de la liste et retour de l'action demandée 
+		$list= $this.getResourceActionList($forResource)
+		return $list | Where-Object { $_.name -eq $actionName }
+	}
+
+
+	<#
+		-------------------------------------------------------------------------------------
+		BUT : Renvoie le template à utiliser pour effectuer une action donnée
+				sur une ressource identifiée par $forResource. Ce template sera ensuite utilisé
+				pour faire une 2nd action sur une ressource après avoir fait quelques 
+				modifications dessus.
+
+		IN  : $forResource 	-> Objet représentant la ressource 
+		IN  : $actionName	-> Nom de l'action
+		
+		RET : Objet contenant le template pour exécuter l'action
+	#>
+	[PSCustomObject] getResourceActionTemplate([PSCustomObject]$forResource,  [String]$actionName)
+	{
+		$actionInfos = $this.getResourceActionInfos($forResource, $actionName)
+
+		# Si l'action que l'on désire effectuer n'existe pas,
+		if($null -eq $actionInfos)
+		{
+			Throw "No action named '{0}' found!" -f $actionName
+		}
+
+		# URL de recherche du template pour l'action que l'on désire effectuer
+		$uri = "https://{0}/catalog-service/api/consumer/resources/{1}/actions/{2}/requests/template/" -f $this.server, $forResource.id, $actionInfos.id
+
+		return $this.callAPI($uri, "Get", $null)
+	}
+
+
+	<#
+		-------------------------------------------------------------------------------------
+		-------------------------------------------------------------------------------------
+									Virtual Machines
+		-------------------------------------------------------------------------------------
+		-------------------------------------------------------------------------------------
+	#>
+
+	<#
+		-------------------------------------------------------------------------------------
+		BUT : Met à jour une custom property sur une VM
+
+		IN  : $vm 				-> Objet représentant la VM à mettre à jour 
+		IN  : $customPropName	-> Nom de la custom property
+		IN  : $customPropValue	-> Valeur de la custom property
+		
+		RET : rien
+	#>
+	[void] updateVMCustomProp([PSCustomObject]$vm, [string]$customPropName, [string]$customPropValue)
+	{
+		# Recherche du template de l'action de reconfiguration car c'est ce qu'on devra utiliser pour 
+		# mettre à jour la custom property
+		$actionTemplate = $this.getResourceActionTemplate($vm, "Reconfigure")
+
+		# On regarde si on trouve la custom property dans la VM pour la mettre à jour
+		$updateOK = $false
+		Foreach($customProp in $actionTemplate.data.customProperties) 
+		{
+			# Si on tombe sur la propriété qu'on cherche 
+			if($customProp.data.id -eq $customPropName)
+			{
+				$customProp.data.value = $customPropValue
+				$updateOK = $true
+				break
+			}
+		}
+
+		# Si on n'a pas pu mettre à jour, c'est que la custom property n'existait pas dans la VM et donc il faut l'ajouter
+		if(!$updateOK)
+		{
+			$replace = @{ customPropName = $customPropName
+						  customPropValue = $customPropValue }
+
+			# Création de la property depuis le JSON
+			$newProp = $this.createObjectFromJSON("vra-resource-action-custom-prop.json", $replace)
+
+			# Ajout à la list
+			$actionTemplate.data.customProperties += $newProp
+		}
+
+
+		$uri = "https://{0}/catalog-service/api/consumer/resources/{1}/actions/{2}/requests" -f $this.server, $actionTemplate.resourceId, $actionTemplate.actionId
+
+		# Mise à jour de la description, bien qu'elle n'apparaîtra nulle part...
+		$actionTemplate.description = "Automatic Backup Tag Update"
+
+		$dummy = $this.callAPI($uri, "Post", $actionTemplate)
+
+	}
 
 
 }

--- a/powershell/include/functions.inc.ps1
+++ b/powershell/include/functions.inc.ps1
@@ -195,7 +195,7 @@ function formatParameters($parameters)
 	-------------------------------------------------------------------------------------
 	BUT : Renvoie la valeur d'une "Custom Property" donnée pour la VM passée
 
-	IN  : $vm				-> Objet représentant le Business Group
+	IN  : $vm				-> Objet représentant la VM
 	IN  : $customPropName	-> Nom de la Custom property à chercher
 	
 	RET : Valeur de la custom property
@@ -205,6 +205,42 @@ function getVMCustomPropValue([object]$vm, [string]$customPropName)
 {
 	# Recherche de la valeur de la "Custom Property" en PowerShell "optmisé"
 	return ($vm.resourceData.entries | Where-Object {$_.key -eq $customPropName}).value.value 
+}
+
+
+<#
+	-------------------------------------------------------------------------------------
+	BUT : Met à jour la valeur d'une "Custom Property" donnée pour la VM passée
+
+	IN  : $vm				-> Objet représentant la VM
+	IN  : $customPropName	-> Nom de la Custom property à mettre à jour
+	IN  : $customPropValue  -> Valeur à mettre pour la custom property
+	
+	RET : Objet représentant la VM avec la valeur modifiée
+#>
+function updateVMCustomPropValue([object]$vm, [string]$customPropName, [string]$customPropValue)
+{
+	# Si la custom prop existe, 
+	if(getVMCustomPropValue -vm $vm -customPropName $customPropName)
+	{
+
+		# Recherche de la valeur de la "Custom Property" en PowerShell "optmisé"
+		($vm.resourceData.entries | Where-Object {$_.key -eq $customPropName}).value.value = $customPropValue
+	}
+	else # La custom prop n'existe pas
+	{
+		# Création de l'objet contenant la nouvelle custom property
+		$newKey = New-Object -TypeName psobject
+		$newKey | Add-Member -NotePropertyName "key" -NotePropertyValue $customPropName
+		
+		$newKey | Add-Member -NotePropertyName "value" -NotePropertyValue (New-Object -TypeName psobject)
+		$newKey.value | Add-Member -NotePropertyName "type" -NotePropertyValue "string"
+		$newKey.value | Add-Member -NotePropertyName "value" -NotePropertyValue $customPropValue
+		
+		$vm.resourceData.entries += $newKey
+	}
+
+	return $vm
 }
 
 <#

--- a/powershell/include/functions.inc.ps1
+++ b/powershell/include/functions.inc.ps1
@@ -210,41 +210,6 @@ function getVMCustomPropValue([object]$vm, [string]$customPropName)
 
 <#
 	-------------------------------------------------------------------------------------
-	BUT : Met à jour la valeur d'une "Custom Property" donnée pour la VM passée
-
-	IN  : $vm				-> Objet représentant la VM
-	IN  : $customPropName	-> Nom de la Custom property à mettre à jour
-	IN  : $customPropValue  -> Valeur à mettre pour la custom property
-	
-	RET : Objet représentant la VM avec la valeur modifiée
-#>
-function updateVMCustomPropValue([object]$vm, [string]$customPropName, [string]$customPropValue)
-{
-	# Si la custom prop existe, 
-	if(getVMCustomPropValue -vm $vm -customPropName $customPropName)
-	{
-
-		# Recherche de la valeur de la "Custom Property" en PowerShell "optmisé"
-		($vm.resourceData.entries | Where-Object {$_.key -eq $customPropName}).value.value = $customPropValue
-	}
-	else # La custom prop n'existe pas
-	{
-		# Création de l'objet contenant la nouvelle custom property
-		$newKey = New-Object -TypeName psobject
-		$newKey | Add-Member -NotePropertyName "key" -NotePropertyValue $customPropName
-		
-		$newKey | Add-Member -NotePropertyName "value" -NotePropertyValue (New-Object -TypeName psobject)
-		$newKey.value | Add-Member -NotePropertyName "type" -NotePropertyValue "string"
-		$newKey.value | Add-Member -NotePropertyName "value" -NotePropertyValue $customPropValue
-		
-		$vm.resourceData.entries += $newKey
-	}
-
-	return $vm
-}
-
-<#
-	-------------------------------------------------------------------------------------
 	BUT : Tronque une chaîne de caractères à une taille définie
 
 	IN  : $str			-> la chaîne à tronquer

--- a/powershell/resources/json-templates/vra-resource-action-custom-prop.json
+++ b/powershell/resources/json-templates/vra-resource-action-custom-prop.json
@@ -1,0 +1,13 @@
+{
+    "componentTypeId": "com.vmware.csp.component.iaas.proxy.provider",
+    "componentId": null,
+    "classId": "Infrastructure.CustomProperty",
+    "typeFilter": null,
+    "data": {
+        "id": "{{customPropName}}",
+        "is_encrypted": false,
+        "is_hidden": false,
+        "prompt_user": false,
+        "value": "{{customPropValue}}"
+    }
+}

--- a/powershell/xaas-backup-sync-vm-tags.ps1
+++ b/powershell/xaas-backup-sync-vm-tags.ps1
@@ -164,17 +164,18 @@ try
 
                 # Recherche du tag attribué à la VM 
                 $vSphereTag = $vsphereApi.getVMTags($vmName, $NBU_TAG_CATEGORY)
-
-                # Si on a trouvé un tag, on récupère son nom.
-                if($null -ne $vSphereTag)
-                {
-                    $vSphereTag = $vSphereTag.Name
-                }
-                else
-                {
-                    $vSphereTag = ""
-                }
             } 
+
+            # Si on a trouvé un tag, on récupère son nom.
+            if($null -ne $vSphereTag)
+            {
+                $vSphereTag = $vSphereTag.Name
+            }
+            else
+            {
+                # On met chaine vide au lieu de $null car plus pratique pour après
+                $vSphereTag = ""
+            }
             
             # Si on n'a pas trouvé de tag de backup pour vRA
             if($null -eq $vRATag)

--- a/powershell/xaas-backup-sync-vm-tags.ps1
+++ b/powershell/xaas-backup-sync-vm-tags.ps1
@@ -1,6 +1,6 @@
 <#
 USAGES:
-    xaas-backup-sync-vm-tags.ps1 -targetEnv prod|test|dev -targetTenant test|itservices|epfl 
+    xaas-backup-sync-vm-tags.ps1 -targetEnv prod|test|dev -targetTenant test|itservices|epfl [-importFromvSphere]
 #>
 <#
     BUT 		: Script lancé par une tâche planifiée, afin de synchroniser, de manière unidirectionnelle,
@@ -25,7 +25,8 @@ USAGES:
     
 #>
 param([string]$targetEnv, 
-      [string]$targetTenant)
+      [string]$targetTenant,
+      [switch]$importFromvSphere)
 
 
 # Inclusion des fichiers nécessaires (génériques)
@@ -120,6 +121,10 @@ try
 						 $configVra.getConfigValue($targetEnv, $targetTenant, "user"), 
 						 $configVra.getConfigValue($targetEnv, $targetTenant, "password"))
 
+    if($importFromvSphere)                         
+    {
+        $logHistory.addLineAndDisplay("!!! Synchronizing from vSphere to vRA !!!")
+    }
 
     # Parcours des Business Groups
     $vra.getBGList() | ForEach-Object {
@@ -137,11 +142,18 @@ try
             
             $vRATag = getVMCustomPropValue -vm $_ -customPropName $VRA_CUSTOM_PROPERTY_BACKUP_TAG
 
-            # Si la propriété existe
-            if($null -ne $vRATag)
-            {
-                $logHistory.addLineAndDisplay("--> Backup tag found! -> {0}" -f (backupTagRepresentation -backupTag $vRATag))
+            $vSphereTag = $null
 
+            # Si la propriété existe
+            # OU
+            # Si on doit synchro depuis vSphere
+            if(($null -ne $vRATag) -or $importFromvSphere)
+            {
+                if($null -ne $vRATag)
+                {
+                    $logHistory.addLineAndDisplay("--> vRA Backup tag found! -> {0}" -f (backupTagRepresentation -backupTag $vRATag))
+                }
+                
                 # Si on ne trouve pas la VM dans vSphere, 
                 if(! $vsphereApi.VMExists($vmName))
                 {
@@ -151,25 +163,45 @@ try
                 }
 
                 # Recherche du tag attribué à la VM 
-                $vmTag = $vsphereApi.getVMTags($vmName, $NBU_TAG_CATEGORY)
+                $vSphereTag = $vsphereApi.getVMTags($vmName, $NBU_TAG_CATEGORY)
 
                 # Si on a trouvé un tag, on récupère son nom.
-                if($null -ne $vmTag)
+                if($null -ne $vSphereTag)
                 {
-                    $vmTag = $vmTag.Name
+                    $vSphereTag = $vSphereTag.Name
                 }
-
-                # Si les tags sont différents 
-                if($vmTag -ne $vRATag)
+                else
                 {
-                    $logHistory.addLineAndDisplay(("--> Tags are different (vRA={0}, vSphere={1}), updating..." -f (backupTagRepresentation -backupTag $vRATag), 
-                                                                                                                   (backupTagRepresentation -backupTag $vmTag)))
+                    $vSphereTag = ""
+                }
+            } 
+            
+            # Si on n'a pas trouvé de tag de backup pour vRA
+            if($null -eq $vRATag)
+            {
+                $logHistory.addLineAndDisplay("--> No vRA backup tag")
+                $vRATag = ""
+            }
 
+            # Si les tags sont différents 
+            if($vSphereTag -ne $vRATag)
+            {
+                $logHistory.addLineAndDisplay(("--> Tags are different (vRA={0}, vSphere={1}), updating..." -f (backupTagRepresentation -backupTag $vRATag), 
+                                                                                                                (backupTagRepresentation -backupTag $vSphereTag)))
+
+                # Si on doit updater vRA depuis vSphere
+                if($importFromvSphere)
+                {
+                    # Mise à jour de la custom property sur la VM dans vRA
+                    $vra.updateVMCustomProp($_, $VRA_CUSTOM_PROPERTY_BACKUP_TAG, $vSphereTag)
+                }
+                else # On doit updater vSphere depuis vRA
+                {
                     # S'il y a effectivement un Tag sur la VM
-                    if($null -ne $vmTag)
+                    if($vSphereTag -ne "")
                     {
                         # Suppression du tag existant dans vSphere
-                        $vsphereApi.detachVMTag($vmName, $vmTag)
+                        $vsphereApi.detachVMTag($vmName, $vSphereTag)
                     }
 
                     # Si le tag dans vRA n'est pas vide, 
@@ -177,23 +209,16 @@ try
                     {
                         $vsphereApi.attachVMTag($vmName, $vRATag)
                     }
-
-                    $counters.inc('UpdatedTags')
                 }
-                else # Le tag dans vRA et dans vSphere est identique
-                {
-                    $logHistory.addLineAndDisplay("--> vSphere tag up-to-date ({0})" -f (backupTagRepresentation -backupTag $vmTag))
-
-                    $counters.inc('CorrectTags')
-                }
-
+                
+                $counters.inc('UpdatedTags')
             }
-            else # La propriété n'existe pas
+            else # Le tag dans vRA et dans vSphere est identique
             {
-                $logHistory.addLineAndDisplay("--> No backup tag")
+                $logHistory.addLineAndDisplay("--> vSphere tag up-to-date ({0})" -f (backupTagRepresentation -backupTag $vSphereTag))
+
+                $counters.inc('CorrectTags')
             }
-
-
 
         } # FIN BOUCLE parcours des VM dans le Business Group
    


### PR DESCRIPTION
Ajout de la possibilité de synchroniser les tags de backup depuis vSphere vers vRA. 
Ceci a nécessité d'implémenter le nécessaire pour exécuter une "2nd day action" sur une ressource existante (une VM en l'occurrence).