### PR TITLE
Allow manual management for support role content

### DIFF
--- a/powershell/include/define.inc.ps1
+++ b/powershell/include/define.inc.ps1
@@ -52,6 +52,7 @@ $global:VRA_CUSTOM_PROP_EPFL_SNOW_SVC_ID = "ch.epfl.snow.svc.id"
 $global:VRA_CUSTOM_PROP_VRA_BG_TYPE = "ch.epfl.vra.bg.type"
 $global:VRA_CUSTOM_PROP_VRA_BG_STATUS = "ch.epfl.vra.bg.status"
 $global:VRA_CUSTOM_PROP_VRA_BG_RES_MANAGE = "ch.epfl.vra.bg.res.manage"
+$global:VRA_CUSTOM_PROP_VRA_BG_ROLE_SUPPORT_MANAGE = "ch.epfl.vra.bg.roles.support.manage"
 
 # Types de Business Group possibles
 $global:VRA_BG_TYPE__ADMIN 	 = "admin"


### PR DESCRIPTION
- Ajout de la possibilité (via une custom prop) de gérer manuellement le contenu du rôle "Support" pour un BG.
Pour ce faire, il faut modifier le contenu de la custom property `ch.epfl.vra.bg.roles.support.manage` et mettre `man` à la place de `auto`
- Simplification du code (suppression de lignes dupliquées) dans la gestion des custom property quand on met à jour/créé un BG