### PR TITLE
New name generator

### DIFF
--- a/powershell/include/NameGenerator.inc.ps1
+++ b/powershell/include/NameGenerator.inc.ps1
@@ -371,58 +371,26 @@ class NameGenerator
         return @($groupName, $groupDesc)
     }
 
-    <# -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- #>
-    <# ----------------------------------------------------------------------------- EPFL --------------------------------------------------------------------------------------- #>
-    <# -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- #>
-
 
     <# 
         -------------------------------------------------------------------------------------
         BUT : Renvoie le nom du groupe AD pour les paramètres passés 
-              Pas utilisé pour CSP_SUPPORT, voir plus bas.
-
-        REMARQUE : ATTENTION A BIEN PASSER DES [int] POUR CERTAINS PARAMETRES !! SI CE N'EST PAS FAIT, C'EST LE 
-                   MAUVAIS PROTOTYPE DE FONCTION QUI RISQUE D'ETRE PRIS EN COMPTE.
-
+              
         IN  : $role             -> Nom du rôle pour lequel on veut le groupe. 
+							        "CSP_SUBTENANT_MANAGER"
+							        "CSP_SUPPORT"
 							        "CSP_CONSUMER_WITH_SHARED_ACCESS"
                                     "CSP_CONSUMER"
-        IN  : $facultyID        -> ID de la faculté du Business Group
-        IN  : $unitID           -> ID de l'unité du Business Group
         IN  : $fqdn             -> Pour dire si on veut le nom avec le nom de domaine après.
                                     $true|$false  
                                     Si pas passé => $false      
     #>
-    [string] getEPFLRoleADGroupName([string]$role, [int]$facultyID, [int]$unitID, [bool]$fqdn)
-    {
-        
+    [string] getRoleADGroupName([string]$role, [bool]$fqdn)
+    {   
         $groupName, $groupDesc = $this.getRoleGroupNameAndDesc($role, $this.GROUP_TYPE_AD, $fqdn)
         return $groupName
     }
 
-    
-    <# 
-        -------------------------------------------------------------------------------------
-        BUT : Renvoie le nom du groupe AD pour les paramètres passés 
-              Utilisé uniquement pour les groupe CSP_SUPPORT et CSP_SUBTENANT_MANAGER. On doit 
-              quand même le passer en  paramètre dans le cas où la fonction devrait évoluer 
-              dans le futur
-
-        IN  : $role             -> Nom du rôle pour lequel on veut le groupe. 
-                                    "CSP_SUPPORT"
-                                    "CSP_SUBTENANT_MANAGER"
-        IN  : $facultyName      -> Nom de la faculté
-        IN  : $fqdn             -> Pour dire si on veut le nom avec le nom de domaine après.
-                                    $true|$false  
-                                    Si pas passé => $false      
-    #>
-    [string] getEPFLRoleADGroupName([string]$role, [string]$facultyName, [bool]$fqdn)
-    {
-        $groupName, $groupDesc = $this.getRoleGroupNameAndDesc($role, $this.GROUP_TYPE_AD, $fqdn)
-        return $groupName
-    }
-    
-    <# -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- #>
 
     <# 
         -------------------------------------------------------------------------------------
@@ -433,17 +401,13 @@ class NameGenerator
 							        "CSP_SUPPORT"
 							        "CSP_CONSUMER_WITH_SHARED_ACCESS"
                                     "CSP_CONSUMER"
-        IN  : $facultyName      -> Le nom de la faculté du Business Group
-        IN  : $unitName         -> Nom de l'unité
     #>
-    [string] getEPFLRoleADGroupDesc([string]$role, [string]$facultyName, [string]$unitName)
+    [string] getRoleADGroupDesc([string]$role)
     {
-      
         $groupName, $groupDesc = $this.getRoleGroupNameAndDesc($role, $this.GROUP_TYPE_AD, $false)
         return $groupDesc
     }
 
-    <# -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- #>
 
     <# 
         -------------------------------------------------------------------------------------
@@ -454,15 +418,13 @@ class NameGenerator
 							        "CSP_SUPPORT"
 							        "CSP_CONSUMER_WITH_SHARED_ACCESS"
                                     "CSP_CONSUMER"
-        IN  : $facultyName      -> Le nom de la faculté du Business Group    
     #>
-    [string] getEPFLRoleGroupsGroupName([string]$role, [string]$facultyName)
+    [string] getRoleGroupsGroupName([string]$role)
     {
         $groupName, $groupDesc = $this.getRoleGroupNameAndDesc($role, $this.GROUP_TYPE_GROUPS, $false)
         return $groupName
     }
 
-    <# -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- #>
 
     <# 
         -------------------------------------------------------------------------------------
@@ -471,13 +433,20 @@ class NameGenerator
         IN  : $role             -> Nom du rôle pour lequel on veut le groupe. 
                                     "CSP_SUPPORT"
                                     "CSP_MANAGER"
-        IN  : $facultyName      -> Le nom de la faculté du Business Group    
     #>
-    [string] getEPFLRoleGroupsADGroupName([string]$role, [string]$facultyName)
+    [string] getRoleGroupsADGroupName([string]$role)
     {
-        $groupName = $this.getEPFLRoleGroupsGroupName($role, $facultyName)
+        $groupName = $this.getRoleGroupsGroupName($role)
         return $groupName + [NameGenerator]::AD_GROUP_GROUPS_SUFFIX
     }
+
+    <# -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- #>
+    <# ----------------------------------------------------------------------------- EPFL --------------------------------------------------------------------------------------- #>
+    <# -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- #>
+
+
+    
+    
 
 
     <# -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- #>
@@ -820,43 +789,6 @@ class NameGenerator
         return $groupDesc
     }    
 
-    <# -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- #>
-
-    <# 
-        -------------------------------------------------------------------------------------
-        BUT : Renvoie le nom du groupe "GROUPS" pour les paramètres passés 
-
-        IN  : $role             -> Nom du rôle pour lequel on veut le groupe. 
-                                    "CSP_SUBTENANT_MANAGER"
-							        "CSP_SUPPORT"
-							        "CSP_CONSUMER_WITH_SHARED_ACCESS"
-                                    "CSP_CONSUMER"
-        IN  : $serviceShortName -> Le nom court du service
-    #>
-    [string] getITSRoleGroupsGroupName([string]$role, [string]$serviceShortName)
-    {
-        $groupName, $groupDesc = $this.getRoleGroupNameAndDesc($role, $this.GROUP_TYPE_GROUPS, $false)
-        return $groupName
-    }
-
-    <# -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- #>
-
-    <# 
-        -------------------------------------------------------------------------------------
-        BUT : Renvoie le nom du groupe "GROUPS" dans Active Directory pour les paramètres passés 
-
-        IN  : $role             -> Nom du rôle pour lequel on veut le groupe. 
-                                    "CSP_SUBTENANT_MANAGER"
-							        "CSP_SUPPORT"
-							        "CSP_CONSUMER_WITH_SHARED_ACCESS"
-                                    "CSP_CONSUMER"
-        IN  : $serviceShortName -> Le nom court du service
-    #>
-    [string] getITSRoleGroupsADGroupName([string]$role, [string]$serviceShortName)
-    {
-        $groupName = $this.getITSRoleGroupsGroupName($role, $serviceShortName)
-        return $groupName + [NameGenerator]::AD_GROUP_GROUPS_SUFFIX
-    }    
 
     <# -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- #>
     <# -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- #>

--- a/powershell/include/NameGenerator.inc.ps1
+++ b/powershell/include/NameGenerator.inc.ps1
@@ -784,10 +784,6 @@ class NameGenerator
         $groupName, $groupDesc = $this.getRoleGroupNameAndDesc($role, $this.GROUP_TYPE_AD, $fqdn, $details)
         return $groupName
     }
-    [string] getITSRoleADGroupName([string]$role, [string] $serviceShortName)
-    {
-        return $this.getITSRoleADGroupName($role, $serviceShortName, $false)
-    }
 
     <# -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- #>
 

--- a/powershell/include/NameGenerator.inc.ps1
+++ b/powershell/include/NameGenerator.inc.ps1
@@ -1123,14 +1123,14 @@ class NameGenerator
 
 		RET : Description du BG
     #>
-    [string] getEntName([string]$facultyName, [string]$unitName)
+    [string] getEntName()
     {
         $name = ""
         switch($this.tenant)
         {
             $global:VRA_TENANT__EPFL 
             { 
-                $name = "{0}_{1}_{2}" -f $this.getTenantShortName(), $this.transformForGroupName($facultyName), $this.transformForGroupName($unitName)
+                $name = "{0}_{1}_{2}" -f $this.getTenantShortName(), $this.transformForGroupName($this.getDetail('facultyName')), $this.transformForGroupName($this.getDetail('unitName'))
             }
 
             $global:VRA_TENANT__ITSERVICES 

--- a/powershell/include/NameGenerator.inc.ps1
+++ b/powershell/include/NameGenerator.inc.ps1
@@ -316,11 +316,7 @@ class NameGenerator
         $groupName, $groupDesc = $this.getRoleGroupNameAndDesc($role, $this.GROUP_TYPE_AD, $fqdn, $details)
         return $groupName
     }
-    
-    [string] getEPFLRoleADGroupName([string]$role, [int]$facultyID, [int]$unitID)
-    {
-        return $this.getEPFLRoleADGroupName($role, $facultyID, $unitID, $false)
-    }
+
     
     <# 
         -------------------------------------------------------------------------------------
@@ -347,10 +343,6 @@ class NameGenerator
         return $groupName
     }
 
-    [string] getEPFLRoleADGroupName([string]$role, [string]$facultyName)
-    {
-        return $this.getEPFLRoleADGroupName($role, $facultyName, $false)
-    }
 
     <# 
         -------------------------------------------------------------------------------------

--- a/powershell/sync-ad-groups-from-ldap-or-django.ps1
+++ b/powershell/sync-ad-groups-from-ldap-or-django.ps1
@@ -369,11 +369,11 @@ try
 			# Il faut créer les groupes pour les Roles CSP_SUBTENANT_MANAGER et CSP_SUPPORT s'ils n'existent pas
 
 			# Génération des noms des groupes dont on va avoir besoin.
-			$adminGroupNameAD = $nameGenerator.getEPFLRoleADGroupName("CSP_SUBTENANT_MANAGER", $faculty['name'])
+			$adminGroupNameAD = $nameGenerator.getEPFLRoleADGroupName("CSP_SUBTENANT_MANAGER", $faculty['name'], $false)
 			$adminGroupDescAD = $nameGenerator.getEPFLRoleADGroupDesc("CSP_SUBTENANT_MANAGER", $faculty['name'])
 			$adminGroupNameGroups = $nameGenerator.getEPFLRoleGroupsADGroupName("CSP_SUBTENANT_MANAGER", $faculty['name'])
 
-			$supportGroupNameAD = $nameGenerator.getEPFLRoleADGroupName("CSP_SUPPORT", $faculty['name'])
+			$supportGroupNameAD = $nameGenerator.getEPFLRoleADGroupName("CSP_SUPPORT", $faculty['name'], $false)
 			$supportGroupDescAD = $nameGenerator.getEPFLRoleADGroupDesc("CSP_SUPPORT", $faculty['name'])
 			$supportGroupNameGroups = $nameGenerator.getEPFLRoleGroupsADGroupName("CSP_SUPPORT", $faculty['name'])
 
@@ -418,7 +418,7 @@ try
 				$ldapMemberList = $ldap.getUnitMembers($unit['uniqueidentifier'])
 
 				# Création du nom du groupe AD et de la description
-				$adGroupName = $nameGenerator.getEPFLRoleADGroupName("CSP_CONSUMER", [int]$faculty['uniqueidentifier'], [int]$unit['uniqueidentifier'])
+				$adGroupName = $nameGenerator.getEPFLRoleADGroupName("CSP_CONSUMER", [int]$faculty['uniqueidentifier'], [int]$unit['uniqueidentifier'], $false)
 				$adGroupDesc = $nameGenerator.getEPFLRoleADGroupDesc("CSP_CONSUMER", $faculty['name'], $unit['name'])
 
 				# Pour définir si un groupe AD a été créé lors de l'itération courante

--- a/powershell/sync-ad-groups-from-ldap-or-django.ps1
+++ b/powershell/sync-ad-groups-from-ldap-or-django.ps1
@@ -678,7 +678,7 @@ try
 			# Génération de nom du groupe dont on va avoir besoin pour les rôles "Admin" et "Support" (même groupe). 
 			# Vu que c'est le même groupe pour les 2 rôles, on peut passer CSP_SUBTENANT_MANAGER ou CSP_SUPPORT aux fonctions, le résultat
 			# sera le même
-			$admSupGroupNameAD = $nameGenerator.getITSRoleADGroupName("CSP_SUBTENANT_MANAGER", $service.shortName)
+			$admSupGroupNameAD = $nameGenerator.getITSRoleADGroupName("CSP_SUBTENANT_MANAGER", $service.shortName, $false)
 			$admSupGroupDescAD = $nameGenerator.getITSRoleADGroupDesc("CSP_SUBTENANT_MANAGER", $service.longName, $service.snowId)
 			$admSupGroupNameGroups = $nameGenerator.getITSRoleGroupsADGroupName("CSP_SUBTENANT_MANAGER", $service.shortName)
 
@@ -698,7 +698,7 @@ try
 			# Génération de nom du groupe dont on va avoir besoin pour les rôles "User" et "Shared" (même groupe).
 			# Vu que c'est le même groupe pour les 2 rôles, on peut passer CSP_CONSUMER_WITH_SHARED_ACCESS ou CSP_CONSUMER aux fonctions, le résultat
 			# sera le même
-			$userSharedGroupNameAD = $nameGenerator.getITSRoleADGroupName("CSP_CONSUMER", $service.shortName)
+			$userSharedGroupNameAD = $nameGenerator.getITSRoleADGroupName("CSP_CONSUMER", $service.shortName, $false)
 			$userSharedGroupDescAD = $nameGenerator.getITSRoleADGroupDesc("CSP_CONSUMER", $service.longName, $service.snowId)
 			$userSharedGroupNameGroups = $nameGenerator.getITSRoleGroupsADGroupName("CSP_CONSUMER", $service.shortName)
 

--- a/powershell/sync-ad-groups-from-ldap-or-django.ps1
+++ b/powershell/sync-ad-groups-from-ldap-or-django.ps1
@@ -331,7 +331,7 @@ try
 			while($true)
 			{
 				$level += 1
-				$approveGroupInfos = $nameGenerator.getEPFLApproveADGroupName($faculty['name'], $level)
+				$approveGroupInfos = $nameGenerator.getEPFLApproveADGroupName($faculty['name'], $level, $false)
 
 				# S'il n'y a plus de groupe pour le level courant, on sort
 				if($null -eq $approveGroupInfos)
@@ -340,7 +340,7 @@ try
 				}
 				
 				$approveGroupDescAD = $nameGenerator.getEPFLApproveADGroupDesc($faculty['name'], $level)
-				$approveGroupNameGroups = $nameGenerator.getEPFLApproveGroupsADGroupName($faculty['name'], $level)
+				$approveGroupNameGroups = $nameGenerator.getEPFLApproveGroupsADGroupName($faculty['name'], $level, $false)
 
 				# Création des groupes + gestion des groupes prérequis 
 				if((createADGroupWithContent -groupName $approveGroupInfos.name -groupDesc $approveGroupDescAD -groupMemberGroup $approveGroupNameGroups `
@@ -370,11 +370,11 @@ try
 
 			# Génération des noms des groupes dont on va avoir besoin.
 			$adminGroupNameAD = $nameGenerator.getEPFLRoleADGroupName("CSP_SUBTENANT_MANAGER", $faculty['name'], $false)
-			$adminGroupDescAD = $nameGenerator.getEPFLRoleADGroupDesc("CSP_SUBTENANT_MANAGER", $faculty['name'])
+			$adminGroupDescAD = $nameGenerator.getEPFLRoleADGroupDesc("CSP_SUBTENANT_MANAGER", $faculty['name'], "")
 			$adminGroupNameGroups = $nameGenerator.getEPFLRoleGroupsADGroupName("CSP_SUBTENANT_MANAGER", $faculty['name'])
 
 			$supportGroupNameAD = $nameGenerator.getEPFLRoleADGroupName("CSP_SUPPORT", $faculty['name'], $false)
-			$supportGroupDescAD = $nameGenerator.getEPFLRoleADGroupDesc("CSP_SUPPORT", $faculty['name'])
+			$supportGroupDescAD = $nameGenerator.getEPFLRoleADGroupDesc("CSP_SUPPORT", $faculty['name'], "")
 			$supportGroupNameGroups = $nameGenerator.getEPFLRoleGroupsADGroupName("CSP_SUPPORT", $faculty['name'])
 
 			# Création des groupes + gestion des groupes prérequis 
@@ -640,7 +640,7 @@ try
 			{
 				$level += 1
 				# Recherche des informations pour le level courant.
-				$approveGroupInfos = $nameGenerator.getITSApproveADGroupName($service.shortName, $level)
+				$approveGroupInfos = $nameGenerator.getITSApproveADGroupName($service.shortName, $level, $false)
 
 				# Si vide, c'est qu'on a atteint le niveau max pour les level
 				if($null -eq $approveGroupInfos)
@@ -649,7 +649,7 @@ try
 				}
 
 				$approveGroupDescAD = $nameGenerator.getITSApproveADGroupDesc($service.longName, $level)
-				$approveGroupNameGroups = $nameGenerator.getITSApproveGroupsADGroupName($service.shortName, $level)
+				$approveGroupNameGroups = $nameGenerator.getITSApproveGroupsADGroupName($service.shortName, $level, $false)
 
 				# Création des groupes + gestion des groupes prérequis 
 				if((createADGroupWithContent -groupName $approveGroupInfos.name -groupDesc $approveGroupDescAD -groupMemberGroup $approveGroupNameGroups `

--- a/powershell/sync-ad-groups-from-ldap-or-django.ps1
+++ b/powershell/sync-ad-groups-from-ldap-or-django.ps1
@@ -339,7 +339,7 @@ try
 			while($true)
 			{
 				$level += 1
-				$approveGroupInfos = $nameGenerator.getEPFLApproveADGroupName($faculty['name'], $level, $false)
+				$approveGroupInfos = $nameGenerator.getApproveADGroupName($level, $false)
 
 				# S'il n'y a plus de groupe pour le level courant, on sort
 				if($null -eq $approveGroupInfos)
@@ -347,8 +347,8 @@ try
 					break
 				}
 				
-				$approveGroupDescAD = $nameGenerator.getEPFLApproveADGroupDesc($faculty['name'], $level)
-				$approveGroupNameGroups = $nameGenerator.getEPFLApproveGroupsADGroupName($faculty['name'], $level, $false)
+				$approveGroupDescAD = $nameGenerator.getApproveADGroupDesc($level)
+				$approveGroupNameGroups = $nameGenerator.getApproveGroupsADGroupName($level, $false)
 
 				# Création des groupes + gestion des groupes prérequis 
 				if((createADGroupWithContent -groupName $approveGroupInfos.name -groupDesc $approveGroupDescAD -groupMemberGroup $approveGroupNameGroups `
@@ -659,7 +659,7 @@ try
 			{
 				$level += 1
 				# Recherche des informations pour le level courant.
-				$approveGroupInfos = $nameGenerator.getITSApproveADGroupName($service.shortName, $level, $false)
+				$approveGroupInfos = $nameGenerator.getApproveADGroupName($level, $false)
 
 				# Si vide, c'est qu'on a atteint le niveau max pour les level
 				if($null -eq $approveGroupInfos)
@@ -667,8 +667,8 @@ try
 					break
 				}
 
-				$approveGroupDescAD = $nameGenerator.getITSApproveADGroupDesc($service.longName, $level)
-				$approveGroupNameGroups = $nameGenerator.getITSApproveGroupsADGroupName($service.shortName, $level, $false)
+				$approveGroupDescAD = $nameGenerator.getApproveADGroupDesc($level)
+				$approveGroupNameGroups = $nameGenerator.getApproveGroupsADGroupName($level, $false)
 
 				# Création des groupes + gestion des groupes prérequis 
 				if((createADGroupWithContent -groupName $approveGroupInfos.name -groupDesc $approveGroupDescAD -groupMemberGroup $approveGroupNameGroups `

--- a/powershell/sync-ad-groups-from-ldap-or-django.ps1
+++ b/powershell/sync-ad-groups-from-ldap-or-django.ps1
@@ -565,7 +565,7 @@ try
 		# Parcours des groupes AD qui sont dans l'OU de l'environnement donné. On ne prend que les groupes qui sont utilisés pour 
 		# donner des droits d'accès aux unités. Afin de faire ceci, on fait un filtre avec une expression régulière
 		Get-ADGroup  -Filter ("Name -like '*'") -SearchBase $nameGenerator.getADGroupsOUDN($true) -Properties Description | 
-		Where-Object {$_.Name -match $nameGenerator.getEPFLADGroupNameRegEx("CSP_CONSUMER")} | 
+		Where-Object {$_.Name -match $nameGenerator.getADGroupNameRegEx("CSP_CONSUMER")} | 
 		ForEach-Object {
 
 			# Si le groupe n'est pas dans ceux créés à partir de LDAP, c'est que l'unité n'existe plus. On supprime donc le groupe AD pour que 

--- a/powershell/sync-ad-groups-from-ldap-or-django.ps1
+++ b/powershell/sync-ad-groups-from-ldap-or-django.ps1
@@ -377,13 +377,13 @@ try
 			# Il faut créer les groupes pour les Roles CSP_SUBTENANT_MANAGER et CSP_SUPPORT s'ils n'existent pas
 
 			# Génération des noms des groupes dont on va avoir besoin.
-			$adminGroupNameAD = $nameGenerator.getEPFLRoleADGroupName("CSP_SUBTENANT_MANAGER", $faculty['name'], $false)
-			$adminGroupDescAD = $nameGenerator.getEPFLRoleADGroupDesc("CSP_SUBTENANT_MANAGER", $faculty['name'], "")
-			$adminGroupNameGroups = $nameGenerator.getEPFLRoleGroupsADGroupName("CSP_SUBTENANT_MANAGER", $faculty['name'])
+			$adminGroupNameAD = $nameGenerator.getRoleADGroupName("CSP_SUBTENANT_MANAGER", $false)
+			$adminGroupDescAD = $nameGenerator.getRoleADGroupDesc("CSP_SUBTENANT_MANAGER")
+			$adminGroupNameGroups = $nameGenerator.getRoleGroupsADGroupName("CSP_SUBTENANT_MANAGER")
 
-			$supportGroupNameAD = $nameGenerator.getEPFLRoleADGroupName("CSP_SUPPORT", $faculty['name'], $false)
-			$supportGroupDescAD = $nameGenerator.getEPFLRoleADGroupDesc("CSP_SUPPORT", $faculty['name'], "")
-			$supportGroupNameGroups = $nameGenerator.getEPFLRoleGroupsADGroupName("CSP_SUPPORT", $faculty['name'])
+			$supportGroupNameAD = $nameGenerator.getRoleADGroupName("CSP_SUPPORT", $false)
+			$supportGroupDescAD = $nameGenerator.getRoleADGroupDesc("CSP_SUPPORT")
+			$supportGroupNameGroups = $nameGenerator.getRoleGroupsADGroupName("CSP_SUPPORT")
 
 			# Création des groupes + gestion des groupes prérequis 
 			if((createADGroupWithContent -groupName $adminGroupNameAD -groupDesc $adminGroupDescAD -groupMemberGroup $adminGroupNameGroups `
@@ -432,8 +432,8 @@ try
 											unitID = $unit['uniqueidentifier']})
 
 				# Création du nom du groupe AD et de la description
-				$adGroupName = $nameGenerator.getEPFLRoleADGroupName("CSP_CONSUMER", [int]$faculty['uniqueidentifier'], [int]$unit['uniqueidentifier'], $false)
-				$adGroupDesc = $nameGenerator.getEPFLRoleADGroupDesc("CSP_CONSUMER", $faculty['name'], $unit['name'])
+				$adGroupName = $nameGenerator.getRoleADGroupName("CSP_CONSUMER", $false)
+				$adGroupDesc = $nameGenerator.getRoleADGroupDesc("CSP_CONSUMER")
 
 				# Pour définir si un groupe AD a été créé lors de l'itération courante
 				$newADGroupCreated = $false
@@ -699,7 +699,7 @@ try
 			# sera le même
 			$admSupGroupNameAD = $nameGenerator.getITSRoleADGroupName("CSP_SUBTENANT_MANAGER", $service.shortName, $false)
 			$admSupGroupDescAD = $nameGenerator.getITSRoleADGroupDesc("CSP_SUBTENANT_MANAGER", $service.longName, $service.snowId)
-			$admSupGroupNameGroups = $nameGenerator.getITSRoleGroupsADGroupName("CSP_SUBTENANT_MANAGER", $service.shortName)
+			$admSupGroupNameGroups = $nameGenerator.getRoleGroupsADGroupName("CSP_SUBTENANT_MANAGER")
 
 			# Création des groupes + gestion des groupes prérequis 
 			if((createADGroupWithContent -groupName $admSupGroupNameAD -groupDesc $admSupGroupDescAD -groupMemberGroup $admSupGroupNameGroups `
@@ -719,7 +719,7 @@ try
 			# sera le même
 			$userSharedGroupNameAD = $nameGenerator.getITSRoleADGroupName("CSP_CONSUMER", $service.shortName, $false)
 			$userSharedGroupDescAD = $nameGenerator.getITSRoleADGroupDesc("CSP_CONSUMER", $service.longName, $service.snowId)
-			$userSharedGroupNameGroups = $nameGenerator.getITSRoleGroupsADGroupName("CSP_CONSUMER", $service.shortName)
+			$userSharedGroupNameGroups = $nameGenerator.getRoleGroupsADGroupName("CSP_CONSUMER")
 
 			# Création des groupes + gestion des groupes prérequis 
 			if((createADGroupWithContent -groupName $userSharedGroupNameAD -groupDesc $userSharedGroupDescAD -groupMemberGroup $userSharedGroupNameGroups `

--- a/powershell/sync-ad-groups-from-ldap-or-django.ps1
+++ b/powershell/sync-ad-groups-from-ldap-or-django.ps1
@@ -322,6 +322,14 @@ try
 			# --------------------------------- FACULTE
 			# ----------------------------------------------------------------------------------
 
+			# Initialisation des détails pour le générateur de noms 
+			# NOTE: On ne connait pas encore toutes les informations donc on initialise 
+			# avec juste celles qui sont nécessaires pour la suite. Le reste, on met une
+			# chaîne vide.
+			$nameGenerator.initDetails(@{facultyName = $faculty['name']
+										facultyID = $faculty['uniqueidentifier']
+										unitName = ''
+										unitID = ''})
 			
 			# --------------------------------- APPROVE
 
@@ -416,6 +424,12 @@ try
 
 				# Recherche des membres de l'unité
 				$ldapMemberList = $ldap.getUnitMembers($unit['uniqueidentifier'])
+
+				# Initialisation des détails pour le générateur de noms
+				$nameGenerator.initDetails(@{facultyName = $faculty['name']
+											facultyID = $faculty['uniqueidentifier']
+											unitName = $unit['name']
+											unitID = $unit['uniqueidentifier']})
 
 				# Création du nom du groupe AD et de la description
 				$adGroupName = $nameGenerator.getEPFLRoleADGroupName("CSP_CONSUMER", [int]$faculty['uniqueidentifier'], [int]$unit['uniqueidentifier'], $false)
@@ -629,6 +643,11 @@ try
 			$logHistory.addLineAndDisplay(("-> [{0}/{1}] Service {2}..." -f $serviceNo, $servicesList.Count, $service.shortName))
 
 			$counters.inc('its.serviceProcessed')
+
+			# Initialisation des détails pour le générateur de noms
+			$nameGenerator.initDetails(@{serviceShortName = $service.shortName
+										serviceName = $service.longName
+										snowServiceId = $service.snowId})
 
 			$serviceNo += 1
 

--- a/powershell/sync-ad-groups-from-ldap-or-django.ps1
+++ b/powershell/sync-ad-groups-from-ldap-or-django.ps1
@@ -697,8 +697,8 @@ try
 			# Génération de nom du groupe dont on va avoir besoin pour les rôles "Admin" et "Support" (même groupe). 
 			# Vu que c'est le même groupe pour les 2 rôles, on peut passer CSP_SUBTENANT_MANAGER ou CSP_SUPPORT aux fonctions, le résultat
 			# sera le même
-			$admSupGroupNameAD = $nameGenerator.getITSRoleADGroupName("CSP_SUBTENANT_MANAGER", $service.shortName, $false)
-			$admSupGroupDescAD = $nameGenerator.getITSRoleADGroupDesc("CSP_SUBTENANT_MANAGER", $service.longName, $service.snowId)
+			$admSupGroupNameAD = $nameGenerator.getRoleADGroupName("CSP_SUBTENANT_MANAGER", $false)
+			$admSupGroupDescAD = $nameGenerator.getRoleADGroupDesc("CSP_SUBTENANT_MANAGER")
 			$admSupGroupNameGroups = $nameGenerator.getRoleGroupsADGroupName("CSP_SUBTENANT_MANAGER")
 
 			# Création des groupes + gestion des groupes prérequis 
@@ -717,8 +717,8 @@ try
 			# Génération de nom du groupe dont on va avoir besoin pour les rôles "User" et "Shared" (même groupe).
 			# Vu que c'est le même groupe pour les 2 rôles, on peut passer CSP_CONSUMER_WITH_SHARED_ACCESS ou CSP_CONSUMER aux fonctions, le résultat
 			# sera le même
-			$userSharedGroupNameAD = $nameGenerator.getITSRoleADGroupName("CSP_CONSUMER", $service.shortName, $false)
-			$userSharedGroupDescAD = $nameGenerator.getITSRoleADGroupDesc("CSP_CONSUMER", $service.longName, $service.snowId)
+			$userSharedGroupNameAD = $nameGenerator.getRoleADGroupName("CSP_CONSUMER", $false)
+			$userSharedGroupDescAD = $nameGenerator.getRoleADGroupDesc("CSP_CONSUMER")
 			$userSharedGroupNameGroups = $nameGenerator.getRoleGroupsADGroupName("CSP_CONSUMER")
 
 			# Création des groupes + gestion des groupes prérequis 

--- a/powershell/sync-bg-from-ad.ps1
+++ b/powershell/sync-bg-from-ad.ps1
@@ -1428,7 +1428,7 @@ try
 
 
 			# Génération du nom et de la description de l'entitlement
-			$entName, $entDesc = $nameGenerator.getEPFLBGEntNameAndDesc($faculty, $unit)
+			$entName, $entDesc = $nameGenerator.getBGEntNameAndDesc()
 
 			# Nom du préfix de machine
 			$machinePrefixName = $nameGenerator.getVMMachinePrefix($faculty)
@@ -1477,13 +1477,13 @@ try
 
 			# -- NSX --
 			# Nom et description du NSGroup
-			$nsxNSGroupName, $nsxNSGroupDesc = $nameGenerator.getEPFLSecurityGroupNameAndDesc($faculty)
+			$nsxNSGroupName, $nsxNSGroupDesc = $nameGenerator.getSecurityGroupNameAndDesc($bgName)
 			# Nom du security Tag
-			$nsxSTName = $nameGenerator.getEPFLSecurityTagName($faculty)
+			$nsxSTName = $nameGenerator.getSecurityTagName()
 			# Nom et description de la section de firewall
-			$nsxFWSectionName, $nsxFWSectionDesc = $nameGenerator.getEPFLFirewallSectionNameAndDesc($faculty)
+			$nsxFWSectionName, $nsxFWSectionDesc = $nameGenerator.getFirewallSectionNameAndDesc()
 			# Nom de règles de firewall
-			$nsxFWRuleNames = $nameGenerator.getEPFLFirewallRuleNames($faculty)
+			$nsxFWRuleNames = $nameGenerator.getFirewallRuleNames()
 
 		}
 		# Si Tenant ITServices
@@ -1507,7 +1507,7 @@ try
 			$bgDesc = $serviceLongName
 			
 			# Génération du nom et de la description de l'entitlement
-			$entName, $entDesc = $nameGenerator.getITSBGEntNameAndDesc($serviceShortName, $serviceLongName)
+			$entName, $entDesc = $nameGenerator.getBGEntNameAndDesc()
 
 			# Nom du préfix de machine
 			# NOTE ! Il n'y a pas de préfix de machine pour les Business Group du tenant ITServices.
@@ -1558,13 +1558,13 @@ try
 
 			# -- NSX --
 			# Nom et description du NSGroup
-			$nsxNSGroupName, $nsxNSGroupDesc = $nameGenerator.getITSSecurityGroupNameAndDesc($serviceShortName, $bgName, $snowServiceId)
+			$nsxNSGroupName, $nsxNSGroupDesc = $nameGenerator.getSecurityGroupNameAndDesc($bgName)
 			# Nom du security Tag
-			$nsxSTName = $nameGenerator.getITSSecurityTagName($serviceShortName)
+			$nsxSTName = $nameGenerator.getSecurityTagName()
 			# Nom et description de la section de firewall
-			$nsxFWSectionName, $nsxFWSectionDesc = $nameGenerator.getITSFirewallSectionNameAndDesc($serviceShortName)
+			$nsxFWSectionName, $nsxFWSectionDesc = $nameGenerator.getFirewallSectionNameAndDesc()
 			# Nom de règles de firewall
-			$nsxFWRuleNames = $nameGenerator.getITSFirewallRuleNames($serviceShortName)
+			$nsxFWRuleNames = $nameGenerator.getFirewallRuleNames()
 		}
 
 		# Contrôle de l'existance des groupes. Si l'un d'eux n'existe pas dans AD, une exception est levée.

--- a/powershell/sync-bg-from-ad.ps1
+++ b/powershell/sync-bg-from-ad.ps1
@@ -1413,6 +1413,12 @@ try
 			$facultyID, $unitID = $nameGenerator.extractInfosFromADGroupName($_.Name)
 			$faculty, $unit = $nameGenerator.extractInfosFromADGroupDesc($_.Description)
 
+			# Initialisation des détails pour le générateur de noms
+			$nameGenerator.initDetails(@{facultyName = $faculty
+										 facultyID = $facultyID
+										 unitName = $unit
+										 unitID = $unitID})
+
 			Write-Debug "-> Current AD group Faculty : $($faculty) ($($facultyID))"
 			Write-Debug "-> Current AD group Unit    : $($unit) ($($unitID)) "
 
@@ -1490,6 +1496,11 @@ try
 			# Vu qu'on reçoit un tableau à un élément, on prend le premier (vu que les autres... n'existent pas)
 			$serviceShortName = $nameGenerator.extractInfosFromADGroupName($_.Name)[0]
 			$snowServiceId, $serviceLongName  = $nameGenerator.extractInfosFromADGroupDesc($_.Description)
+
+			# Initialisation des détails pour le générateur de noms
+			$nameGenerator.initDetails(@{serviceShortName = $serviceShortName
+				serviceName = $serviceLongName
+				snowServiceId = $snowServiceId})
 
 			# Création du nom/description du business group
 			$bgName = $nameGenerator.getBGName($serviceShortName)

--- a/powershell/sync-bg-from-ad.ps1
+++ b/powershell/sync-bg-from-ad.ps1
@@ -1365,14 +1365,8 @@ try
 	 groupe pour filtrer mais d'autres groupes avec des noms débutant de la même manière ont été ajoutés donc le filtre par expression régulière
 	 a été nécessaire.
 	#>
-	if($targetTenant -eq $global:VRA_TENANT__EPFL)
-	{
-		$adGroupNameRegex = $nameGenerator.getADGroupNameRegEx("CSP_CONSUMER")
-	}
-	else 
-	{
-		$adGroupNameRegex = $nameGenerator.getADGroupNameRegEx("CSP_CONSUMER")
-	}
+	$adGroupNameRegex = $nameGenerator.getADGroupNameRegEx("CSP_CONSUMER")
+	
 	$adGroupList = Get-ADGroup -Filter ("Name -like '*'") -Server ad2.epfl.ch -SearchBase $nameGenerator.getADGroupsOUDN($true) -Properties Description | 
 	Where-Object {$_.Name -match $adGroupNameRegex} 
 
@@ -1424,7 +1418,7 @@ try
 			Write-Debug "-> Current AD group Unit    : $($unit) ($($unitID)) "
 
 			# Création du nom/description du business group
-			$bgName = $nameGenerator.getBGName($faculty, $unit)
+			$bgName = $nameGenerator.getBGName()
 			$bgDesc = $nameGenerator.getBGDescription()
 
 
@@ -1504,7 +1498,7 @@ try
 				snowServiceId = $snowServiceId})
 
 			# Création du nom/description du business group
-			$bgName = $nameGenerator.getBGName($serviceShortName)
+			$bgName = $nameGenerator.getBGName()
 			$bgDesc = $serviceLongName
 			
 			# Génération du nom et de la description de l'entitlement

--- a/powershell/sync-bg-from-ad.ps1
+++ b/powershell/sync-bg-from-ad.ps1
@@ -1424,14 +1424,14 @@ try
 
 			# Création du nom/description du business group
 			$bgName = $nameGenerator.getBGName($faculty, $unit)
-			$bgDesc = $nameGenerator.getEPFLBGDescription($faculty, $unit)
+			$bgDesc = $nameGenerator.getBGDescription()
 
 
 			# Génération du nom et de la description de l'entitlement
 			$entName, $entDesc = $nameGenerator.getBGEntNameAndDesc()
 
 			# Nom du préfix de machine
-			$machinePrefixName = $nameGenerator.getVMMachinePrefix($faculty)
+			$machinePrefixName = $nameGenerator.getVMMachinePrefix()
 
 			# Custom properties du Buisness Group
 			$bgCustomProperties = @{"$global:VRA_CUSTOM_PROP_EPFL_UNIT_ID" = $unitID}
@@ -1517,8 +1517,8 @@ try
 			$bgCustomProperties = @{"$global:VRA_CUSTOM_PROP_EPFL_SNOW_SVC_ID" = $snowServiceId}
 
 			# Groupes de sécurités AD pour les différents rôles du BG
-			$managerGrpList = @($nameGenerator.getITSRoleADGroupName("CSP_SUBTENANT_MANAGER", $serviceShortName, $true))
-			$supportGrpList = @($nameGenerator.getITSRoleADGroupName("CSP_SUPPORT", $serviceShortName, $true))
+			$managerGrpList = @($nameGenerator.getRoleADGroupName("CSP_SUBTENANT_MANAGER", $true))
+			$supportGrpList = @($nameGenerator.getRoleADGroupName("CSP_SUPPORT", $true))
 			# Pas besoin de "générer" le nom du groupe ici car on le connaît déjà vu qu'on est en train de parcourir les groupes AD
 			# créés par le script "sync-ad-groups-from-ldap.ps1"
 			$sharedGrpList  = @($ADFullGroupName)

--- a/powershell/sync-bg-from-ad.ps1
+++ b/powershell/sync-bg-from-ad.ps1
@@ -1437,8 +1437,8 @@ try
 			$bgCustomProperties = @{"$global:VRA_CUSTOM_PROP_EPFL_UNIT_ID" = $unitID}
 
 			# Groupes de sécurités AD pour les différents rôles du BG
-			$managerGrpList = @($nameGenerator.getEPFLRoleADGroupName("CSP_SUBTENANT_MANAGER", $faculty, $true))
-			$supportGrpList = @($nameGenerator.getEPFLRoleADGroupName("CSP_SUPPORT", $faculty, $true))
+			$managerGrpList = @($nameGenerator.getRoleADGroupName("CSP_SUBTENANT_MANAGER", $true))
+			$supportGrpList = @($nameGenerator.getRoleADGroupName("CSP_SUPPORT", $true))
 			# Pas besoin de "générer" le nom du groupe ici car on le connaît déjà vu qu'on est en train de parcourir les groupes AD
 			# créés par le script "sync-ad-groups-from-ldap.ps1"
 			$sharedGrpList  = @($ADFullGroupName)

--- a/powershell/sync-bg-from-ad.ps1
+++ b/powershell/sync-bg-from-ad.ps1
@@ -1446,11 +1446,11 @@ try
 			
 			# Ajout de l'adresse mail à laquelle envoyer les "capacity alerts" pour le BG. On prend le niveau 1 car c'est celui de EXHEB
 			# NOTE : 15.02.2019 - Les approbations pour les ressources sont faites par admin IaaS (level 1), donc plus besoin d'info aux approbateurs level 2
-			#$capacityAlertMails += $nameGenerator.getEPFLApproveGroupsEmail($faculty, 1)
+			#$capacityAlertMails += $nameGenerator.getApproveGroupsEmail(1)
 
 			# Nom et description de la policy d'approbation + nom du groupe AD qui devra approuver
-			$itemReqApprovalPolicyName, $itemReqApprovalPolicyDesc = $nameGenerator.getEPFLApprovalPolicyNameAndDesc($faculty, $global:APPROVE_POLICY_TYPE__ITEM_REQ)
-			$actionReqBaseApprovalPolicyName, $actionReqApprovalPolicyDesc = $nameGenerator.getEPFLApprovalPolicyNameAndDesc($faculty, $global:APPROVE_POLICY_TYPE__ACTION_REQ)
+			$itemReqApprovalPolicyName, $itemReqApprovalPolicyDesc = $nameGenerator.getApprovalPolicyNameAndDesc($global:APPROVE_POLICY_TYPE__ITEM_REQ)
+			$actionReqBaseApprovalPolicyName, $actionReqApprovalPolicyDesc = $nameGenerator.getApprovalPolicyNameAndDesc($global:APPROVE_POLICY_TYPE__ACTION_REQ)
 			
 			# Tableau pour les approbateurs des différents niveaux
 			$approverGroupAtDomainList = @()
@@ -1459,7 +1459,7 @@ try
 			While($true)
 			{
 				$level += 1
-				$levelGroupInfos = $nameGenerator.getEPFLApproveADGroupName($faculty, $level, $true)
+				$levelGroupInfos = $nameGenerator.getApproveADGroupName($level, $true)
 				# Si on n'a plus de groupe pour le level courant, on sort
 				if($null -eq $levelGroupInfos)
 				{
@@ -1526,11 +1526,11 @@ try
 
 			# Ajout de l'adresse mail à laquelle envoyer les "capacity alerts" pour le BG
 			# NOTE : 15.02.2019 - Les approbations pour les ressources sont faites par admin IaaS (level 1), donc plus besoin d'info aux approbateurs level 2
-			#$capacityAlertMails += $nameGenerator.getITSApproveGroupsEmail($serviceShortName, 1)
+			#$capacityAlertMails += $nameGenerator.getApproveGroupsEmail(1)
 
 			# Nom de la policy d'approbation ainsi que du groupe d'approbateurs
-			$itemReqApprovalPolicyName, $itemReqApprovalPolicyDesc = $nameGenerator.getITSApprovalPolicyNameAndDesc($serviceShortName, $serviceLongName, $global:APPROVE_POLICY_TYPE__ITEM_REQ)
-			$actionReqBaseApprovalPolicyName, $actionReqApprovalPolicyDesc = $nameGenerator.getITSApprovalPolicyNameAndDesc($serviceShortName, $serviceLongName, $global:APPROVE_POLICY_TYPE__ACTION_REQ)
+			$itemReqApprovalPolicyName, $itemReqApprovalPolicyDesc = $nameGenerator.getApprovalPolicyNameAndDesc($global:APPROVE_POLICY_TYPE__ITEM_REQ)
+			$actionReqBaseApprovalPolicyName, $actionReqApprovalPolicyDesc = $nameGenerator.getApprovalPolicyNameAndDesc($global:APPROVE_POLICY_TYPE__ACTION_REQ)
 			
 			# Tableau pour les approbateurs des différents niveaux
 			$approverGroupAtDomainList = @()
@@ -1539,7 +1539,7 @@ try
 			While($true)
 			{
 				$level += 1
-				$levelGroupInfos = $nameGenerator.getITSApproveADGroupName($serviceShortName, $level, $true)
+				$levelGroupInfos = $nameGenerator.getApproveADGroupName($level, $true)
 
 				# Si on a un nom de groupe vide, c'est qu'il n'y a aucun groupe pour le level courant donc on peut sortir de la boucle
 				if($null -eq $levelGroupInfos)

--- a/powershell/sync-bg-from-ad.ps1
+++ b/powershell/sync-bg-from-ad.ps1
@@ -1366,11 +1366,11 @@ try
 	#>
 	if($targetTenant -eq $global:VRA_TENANT__EPFL)
 	{
-		$adGroupNameRegex = $nameGenerator.getEPFLADGroupNameRegEx("CSP_CONSUMER")
+		$adGroupNameRegex = $nameGenerator.getADGroupNameRegEx("CSP_CONSUMER")
 	}
 	else 
 	{
-		$adGroupNameRegex = $nameGenerator.getITSADGroupNameRegEx("CSP_CONSUMER")
+		$adGroupNameRegex = $nameGenerator.getADGroupNameRegEx("CSP_CONSUMER")
 	}
 	$adGroupList = Get-ADGroup -Filter ("Name -like '*'") -Server ad2.epfl.ch -SearchBase $nameGenerator.getADGroupsOUDN($true) -Properties Description | 
 	Where-Object {$_.Name -match $adGroupNameRegex} 

--- a/powershell/tests/include/ClassTester.inc.ps1
+++ b/powershell/tests/include/ClassTester.inc.ps1
@@ -89,7 +89,7 @@ class ClassTester
             $testList = (Get-Content -Path $jsonTestFile -raw) | ConvertFrom-Json    
         }
         catch {
-            Write-Error ("Error loading JSON file {0}" -f $jsonTestFile)
+            Write-Error ("Error loading JSON file {0}`n{1}" -f $jsonTestFile, $_)
             exit
         }
         

--- a/powershell/tests/test-namegenerator-epfl.json
+++ b/powershell/tests/test-namegenerator-epfl.json
@@ -1,6 +1,6 @@
 [
     {
-        "name": "getEPFLADGroupNameRegEx",
+        "name": "getADGroupNameRegEx",
         "tests": [
             {
                 "params": ["CSP_SUBTENANT_MANAGER"],
@@ -22,137 +22,137 @@
         ]
     },
     {
-        "name": "getEPFLRoleADGroupName",
+        "name": "getRoleADGroupName",
         "tests": [
             {
-                "params": ["CSP_CONSUMER_WITH_SHARED_ACCESS", "12635", "13031", true],
+                "params": ["CSP_CONSUMER_WITH_SHARED_ACCESS", true],
                 "expected": "vra_t_12635_13031@intranet.epfl.ch"
             },
             {
-                "params": ["CSP_CONSUMER_WITH_SHARED_ACCESS", "12635", "13031", false],
+                "params": ["CSP_CONSUMER_WITH_SHARED_ACCESS", false],
                 "expected": "vra_t_12635_13031"
             },
             {
-                "params": ["CSP_CONSUMER", "12635", "13031", true],
+                "params": ["CSP_CONSUMER", true],
                 "expected": "vra_t_12635_13031@intranet.epfl.ch"
             },
             {
-                "params": ["CSP_CONSUMER", "12635", "13031", false],
+                "params": ["CSP_CONSUMER", false],
                 "expected": "vra_t_12635_13031"
             },
 
             {
-                "params": ["CSP_SUPPORT", "12635", true],
-                "expected": "vra_t_sup_12635@intranet.epfl.ch"
+                "params": ["CSP_SUPPORT", true],
+                "expected": "vra_t_sup_si@intranet.epfl.ch"
             },
             {
-                "params": ["CSP_SUPPORT", "12635", false],
-                "expected": "vra_t_sup_12635"
+                "params": ["CSP_SUPPORT", false],
+                "expected": "vra_t_sup_si"
             },
             {
-                "params": ["CSP_SUBTENANT_MANAGER", "12635", true],
+                "params": ["CSP_SUBTENANT_MANAGER", true],
                 "expected": "vra_t_adm_epfl@intranet.epfl.ch"
             },
             {
-                "params": ["CSP_SUBTENANT_MANAGER", "12635", false],
+                "params": ["CSP_SUBTENANT_MANAGER", false],
                 "expected": "vra_t_adm_epfl"
             }
         ]
     },
 
     {
-        "name": "getEPFLRoleADGroupDesc",
+        "name": "getRoleADGroupDesc",
         "tests": [
             {
-                "params": ["CSP_SUPPORT", "SI", true],
+                "params": ["CSP_SUPPORT"],
                 "expected": "Support for Faculty SI on Tenant EPFL on Environment TEST"
             },
             {
-                "params": ["CSP_SUPPORT", "SI", false],
+                "params": ["CSP_SUPPORT"],
                 "expected": "Support for Faculty SI on Tenant EPFL on Environment TEST"
             },
             {
-                "params": ["CSP_SUBTENANT_MANAGER", "SI", true],
+                "params": ["CSP_SUBTENANT_MANAGER"],
                 "expected": "Administrators for Tenant EPFL on Environment TEST"
             },
             {
-                "params": ["CSP_SUBTENANT_MANAGER", "SI", false],
+                "params": ["CSP_SUBTENANT_MANAGER"],
                 "expected": "Administrators for Tenant EPFL on Environment TEST"
             },
 
             {
-                "params": ["CSP_SUBTENANT_MANAGER", "SI", "IDEV-ING"],
+                "params": ["CSP_SUBTENANT_MANAGER"],
                 "expected": "Administrators for Tenant EPFL on Environment TEST"
             },
             {
-                "params": ["CSP_SUPPORT", "SI", "IDEV-ING"],
+                "params": ["CSP_SUPPORT"],
                 "expected": "Support for Faculty SI on Tenant EPFL on Environment TEST"
             },
             {
-                "params": ["CSP_CONSUMER_WITH_SHARED_ACCESS", "SI", "IDEV-ING"],
+                "params": ["CSP_CONSUMER_WITH_SHARED_ACCESS"],
                 "expected": "SI;IDEV-ING"
             },
             {
-                "params": ["CSP_CONSUMER", "SI", "IDEV-ING"],
+                "params": ["CSP_CONSUMER"],
                 "expected": "SI;IDEV-ING"
             }
         ]
     },
 
     {
-        "name": "getEPFLRoleGroupsGroupName",
+        "name": "getRoleGroupsGroupName",
         "tests": [
             {
-                "params": ["CSP_SUBTENANT_MANAGER", "SI"],
+                "params": ["CSP_SUBTENANT_MANAGER"],
                 "expected": "vra_t_adm_epfl"
             },
             {
-                "params": ["CSP_SUPPORT", "SI"],
+                "params": ["CSP_SUPPORT"],
                 "expected": "vra_t_sup_si"
             }
         ]
     },
 
     {
-        "name": "getEPFLRoleGroupsADGroupName",
+        "name": "getRoleGroupsADGroupName",
         "tests": [
             {
-                "params": ["CSP_SUPPORT", "SI"],
+                "params": ["CSP_SUPPORT"],
                 "expected": "vra_t_sup_si_AppGrpU"
             },
             {
-                "params": ["CSP_SUBTENANT_MANAGER", "SI"],
+                "params": ["CSP_SUBTENANT_MANAGER"],
                 "expected": "vra_t_adm_epfl_AppGrpU"
             }
         ]
     },
 
     {
-        "name": "getEPFLApproveADGroupName",
+        "name": "getApproveADGroupName",
         "tests": [
             {
-                "params":["SI", 1, true],
+                "params":[1, true],
                 "expected": {
                     "onlyForTenant": false,
                     "name": "vra_t_approval_service_manager@intranet.epfl.ch"
                 }
             },
             {
-                "params":["SI", 1, false],
+                "params":[1, false],
                 "expected": {
                     "onlyForTenant": false,
                     "name": "vra_t_approval_service_manager"
                 }
             },
             {
-                "params":["SI", 2, true],
+                "params":[2, true],
                 "expected": {
                     "onlyForTenant": true,
                     "name": "vra_t_approval_si@intranet.epfl.ch"
                 }
             },
             {
-                "params":["SI", 2, false],
+                "params":[2, false],
                 "expected": {
                     "onlyForTenant": true,
                     "name": "vra_t_approval_si"
@@ -163,17 +163,17 @@
     },
 
     {
-        "name": "getEPFLApproveGroupsGroupName",
+        "name": "getApproveGroupsGroupName",
         "tests": [
              {
-                "params":["SI", 1, false],
+                "params":[1, false],
                 "expected": {
                     "onlyForTenant": false,
                     "name": "vra_t_approval_service_manager"
                 }
             },
             {
-                "params":["SI", 2, false],
+                "params":[2, false],
                 "expected": {
                     "onlyForTenant": true,
                     "name": "vra_t_approval_si"
@@ -183,106 +183,106 @@
     },
 
     {
-        "name": "getEPFLApproveGroupsEmail",
+        "name": "getApproveGroupsEmail",
         "tests":[
             {
-                "params":["SI", 1],
+                "params":[1],
                 "expected": "vra_t_approval_service_manager@groupes.epfl.ch"
             },
             {
-                "params":["SI", 2],
+                "params":[2],
                 "expected": "vra_t_approval_si@groupes.epfl.ch"
             }
         ]
     },
 
     {
-        "name": "getEPFLApproveADGroupDesc",
+        "name": "getApproveADGroupDesc",
         "tests":[
             {
-                "params":["SI", 1],
+                "params":[1],
                 "expected": "Approval group (level 1)"
             },
             {
-                "params":["SI", 2],
+                "params":[2],
                 "expected": "Approval group (level 2) for Faculty: SI"
             }
         ]
     },
 
     {
-        "name": "getEPFLApproveGroupsADGroupName",
+        "name": "getApproveGroupsADGroupName",
         "tests": [
             {
-                "params":["SI", 1, false],
+                "params":[1, false],
                 "expected": "vra_t_approval_service_manager_AppGrpU"
             },
             {
-                "params":["SI", 2, false],
+                "params":[2, false],
                 "expected": "vra_t_approval_si_AppGrpU"
             }
         ]
     },
 
     {
-        "name": "getEPFLApprovalPolicyNameAndDesc",
+        "name": "getApprovalPolicyNameAndDesc",
         "tests":[
             {
-                "params":["SI", "new"],
+                "params":["new"],
                 "expected": ["epfl_si_newItems", "Approval policy for new items for SI Faculty"]
             },
             {
-                "params":["SI", "reconfigure"],
+                "params":["reconfigure"],
                 "expected": ["epfl_si_2ndDay", "Approval policy for 2nd day actions for SI Faculty"]
             }
         ]
     },
 
     {
-        "name": "getEPFLBGEntNameAndDesc",
+        "name": "getBGEntNameAndDesc",
         "tests": [
             {
-                "params":["SI", "IDEV-ING"],
+                "params":[],
                 "expected": ["epfl_si_idev_ing", "Faculty: SI\nUnit: IDEV-ING"]
             }
         ]
     },
 
     {
-        "name": "getEPFLSecurityGroupNameAndDesc",
+        "name": "getSecurityGroupNameAndDesc",
         "tests":[
             {
-                "params": ["SI"],
+                "params": ["epfl_si_idev_ing"],
                 "expected": ["sg.epfl_SI", "Tenant: epfl\\nFaculty: SI"]
             }
         ]
     },
 
     {
-        "name": "getEPFLSecurityTagName",
+        "name": "getSecurityTagName",
         "tests":[
             {
-                "params":["SI"],
+                "params":[],
                 "expected":"st.epfl_si"
             }
         ]
     },
 
     {
-        "name": "getEPFLFirewallSectionNameAndDesc",
+        "name": "getFirewallSectionNameAndDesc",
         "tests": [
             {
-                "params":["SI"],
+                "params":[],
                 "expected": ["epfl_si","Section for Tenant epfl and Faculty SI"]
             }
         ]   
     },
 
     {
-        "name": "getEPFLFirewallRuleNames",
+        "name": "getFirewallRuleNames",
         "tests":[
             {
-                "params":["SI"],
+                "params":[],
                 "expected":[
                     {
                         "tag": "allow-SI-in",
@@ -323,17 +323,17 @@
         "name": "getVMMachinePrefix",
         "tests":[
             {
-                "params": ["SI"],
+                "params": [],
                 "expected": "sitvm"
             }
         ]
     },
 
     {
-        "name": "getEPFLBGDescription",
+        "name": "getBGDescription",
         "tests":[
             {
-                "params": ["SI", "IDEV-ING"],
+                "params": [],
                 "expected": "Faculty: SI\nUnit: IDEV-ING"
             }
         ]
@@ -343,7 +343,7 @@
         "name": "getEntName",
         "tests":[
             {
-                "params": ["SI", "IDEV-ING"],
+                "params": [],
                 "expected": "epfl_si_idev_ing"
             }
         ]
@@ -353,7 +353,7 @@
         "name": "getEntDescription",
         "tests":[
             {
-                "params": ["SI", "IDEV-ING"],
+                "params": [],
                 "expected": "Faculty: SI\nUnit: IDEV-ING"
             }
         ]
@@ -383,7 +383,7 @@
         "name": "getBGName",
         "tests":[
             {
-                "params": ["SI", "IDEV-ING"],
+                "params": [],
                 "expected": "epfl_si_idev_ing"
             }
         ]

--- a/powershell/tests/test-namegenerator-epfl.json
+++ b/powershell/tests/test-namegenerator-epfl.json
@@ -1,5 +1,21 @@
 [
     {
+        "name": "initDetails",
+        "tests": [
+            {
+                "params": [
+                    {
+                        "facultyName": "SI",
+                        "facultyID": "12635",
+                        "unitName": "IDEV-ING",
+                        "unitID": "13031"
+                    }
+                ],
+                "expected": null
+            }
+        ]
+    },
+    {
         "name": "getADGroupNameRegEx",
         "tests": [
             {

--- a/powershell/tests/test-namegenerator-itservices.json
+++ b/powershell/tests/test-namegenerator-itservices.json
@@ -1,6 +1,6 @@
 [
     {
-        "name": "getITSADGroupNameRegEx",
+        "name": "getADGroupNameRegEx",
         "tests": [
             {
                 "params": ["CSP_SUBTENANT_MANAGER"],
@@ -22,134 +22,134 @@
         ]
     },
     {
-        "name": "getITSRoleADGroupName",
+        "name": "getRoleADGroupName",
         "tests": [
             {
-                "params": ["CSP_SUBTENANT_MANAGER", "vs", true],
+                "params": ["CSP_SUBTENANT_MANAGER", true],
                 "expected": "vra_t_adm_sup_its@intranet.epfl.ch"
             },
             {
-                "params": ["CSP_SUBTENANT_MANAGER", "vs", false],
+                "params": ["CSP_SUBTENANT_MANAGER", false],
                 "expected": "vra_t_adm_sup_its"
             },
             {
-                "params": ["CSP_SUPPORT", "vs", true],
+                "params": ["CSP_SUPPORT", true],
                 "expected": "vra_t_adm_sup_its@intranet.epfl.ch"
             },
             {
-                "params": ["CSP_SUPPORT", "vs", false],
+                "params": ["CSP_SUPPORT", false],
                 "expected": "vra_t_adm_sup_its"
             },
             {
-                "params": ["CSP_CONSUMER_WITH_SHARED_ACCESS", "vs", true],
+                "params": ["CSP_CONSUMER_WITH_SHARED_ACCESS", true],
                 "expected": "vra_t_vs@intranet.epfl.ch"
             },
             {
-                "params": ["CSP_CONSUMER_WITH_SHARED_ACCESS", "vs", false],
+                "params": ["CSP_CONSUMER_WITH_SHARED_ACCESS", false],
                 "expected": "vra_t_vs"
             },
             {
-                "params": ["CSP_CONSUMER", "vs", true],
+                "params": ["CSP_CONSUMER", true],
                 "expected": "vra_t_vs@intranet.epfl.ch"
             },
             {
-                "params": ["CSP_CONSUMER", "vs", false],
+                "params": ["CSP_CONSUMER", false],
                 "expected": "vra_t_vs"
             }
         ]
     },
 
     {
-        "name": "getITSRoleADGroupDesc",
+        "name": "getRoleADGroupDesc",
         "tests": [
             {
-                "params": ["CSP_SUPPORT", "vs", "SVC0007"],
+                "params": ["CSP_SUPPORT"],
                 "expected": "Administrators/Support for Tenant ITSERVICES on Environment TEST"
             },
             {
-                "params": ["CSP_CONSUMER", "vs", "SVC0007"],
-                "expected": "SVC0007;vs"
+                "params": ["CSP_CONSUMER"],
+                "expected": "SVC0007;Virtualization Service"
             },
             {
-                "params": ["CSP_SUBTENANT_MANAGER", "vs", "SVC0007"],
+                "params": ["CSP_SUBTENANT_MANAGER"],
                 "expected": "Administrators/Support for Tenant ITSERVICES on Environment TEST"
             },
             {
-                "params": ["CSP_CONSUMER_WITH_SHARED_ACCESS", "vs", "SVC0007"],
-                "expected": "SVC0007;vs"
+                "params": ["CSP_CONSUMER_WITH_SHARED_ACCESS"],
+                "expected": "SVC0007;Virtualization Service"
             }
         ]
     },
 
     {
-        "name": "getITSRoleGroupsGroupName",
+        "name": "getRoleGroupsGroupName",
         "tests": [
             {
-                "params": ["CSP_SUBTENANT_MANAGER", "vs"],
+                "params": ["CSP_SUBTENANT_MANAGER"],
                 "expected": "vra_t_adm_sup_its"
             },
             {
-                "params": ["CSP_CONSUMER_WITH_SHARED_ACCESS", "vs"],
+                "params": ["CSP_CONSUMER_WITH_SHARED_ACCESS"],
                 "expected": "vra_t_vs"
             },
             {
-                "params": ["CSP_CONSUMER", "vs"],
+                "params": ["CSP_CONSUMER"],
                 "expected": "vra_t_vs"
             },
             {
-                "params": ["CSP_SUPPORT", "vs"],
+                "params": ["CSP_SUPPORT"],
                 "expected": "vra_t_adm_sup_its"
             }
         ]
     },
     {
-        "name": "getITSRoleGroupsADGroupName",
+        "name": "getRoleGroupsADGroupName",
         "tests": [
             {
-                "params": ["CSP_SUPPORT", "vs"],
+                "params": ["CSP_SUPPORT"],
                 "expected": "vra_t_adm_sup_its_AppGrpU"
             },
             {
-                "params": ["CSP_SUBTENANT_MANAGER", "vs"],
+                "params": ["CSP_SUBTENANT_MANAGER"],
                 "expected": "vra_t_adm_sup_its_AppGrpU"
             },
             {
-                "params": ["CSP_CONSUMER", "vs"],
+                "params": ["CSP_CONSUMER"],
                 "expected": "vra_t_vs_AppGrpU"
             },
             {
-                "params": ["CSP_CONSUMER_WITH_SHARED_ACCESS", "vs"],
+                "params": ["CSP_CONSUMER_WITH_SHARED_ACCESS"],
                 "expected": "vra_t_vs_AppGrpU"
             }
         ]
     },
 
     {
-        "name": "getITSApproveADGroupName",
+        "name": "getApproveADGroupName",
         "tests": [
             {
-                "params":["vs", 1, true],
+                "params":[1, true],
                 "expected": {
                     "onlyForTenant": false,
                     "name": "vra_t_approval_service_manager@intranet.epfl.ch"
                 }
             },
             {
-                "params":["vs", 1, false],
+                "params":[1, false],
                 "expected": {
                     "onlyForTenant": false,
                     "name": "vra_t_approval_service_manager"
                 }
             },
             {
-                "params":["vs", 2, true],
+                "params":[2, true],
                 "expected": {
                     "onlyForTenant": true,
                     "name": "vra_t_approval_service_chiefs@intranet.epfl.ch"
                 }
             },
             {
-                "params":["vs", 2, false],
+                "params":[2, false],
                 "expected": {
                     "onlyForTenant": true,
                     "name": "vra_t_approval_service_chiefs"
@@ -160,17 +160,17 @@
     },
 
     {
-        "name": "getITSApproveGroupsGroupName",
+        "name": "getApproveGroupsGroupName",
         "tests": [
              {
-                "params":["vs", 1, false],
+                "params":[1, false],
                 "expected": {
                     "onlyForTenant": false,
                     "name": "vra_t_approval_service_manager"
                 }
             },
             {
-                "params":["vs", 2, false],
+                "params":[2, false],
                 "expected": {
                     "onlyForTenant": true,
                     "name": "vra_t_approval_service_chiefs"
@@ -180,106 +180,106 @@
     },
 
     {
-        "name": "getITSApproveGroupsEmail",
+        "name": "getApproveGroupsEmail",
         "tests":[
             {
-                "params":["vs", 1],
+                "params":[1],
                 "expected": "vra_t_approval_service_manager@groupes.epfl.ch"
             },
             {
-                "params":["vs", 2],
+                "params":[2],
                 "expected": "vra_t_approval_service_chiefs@groupes.epfl.ch"
             }
         ]
     },
 
     {
-        "name": "getITSApproveGroupsADGroupName",
+        "name": "getApproveGroupsADGroupName",
         "tests": [
             {
-                "params":["vs", 1, false],
+                "params":[1, false],
                 "expected": "vra_t_approval_service_manager_AppGrpU"
             },
             {
-                "params":["vs", 2, false],
+                "params":[2, false],
                 "expected": "vra_t_approval_service_chiefs_AppGrpU"
             }
         ]
     },
 
     {
-        "name": "getITSApproveADGroupDesc",
+        "name": "getApproveADGroupDesc",
         "tests":[
             {
-                "params":["vs", 1],
+                "params":[1],
                 "expected": "Approval group (level 1)"
             },
             {
-                "params":["vs", 2],
+                "params":[2],
                 "expected": "Approval group (level 2)"
             }
         ]
     },
 
     {
-        "name": "getITSApprovalPolicyNameAndDesc",
+        "name": "getApprovalPolicyNameAndDesc",
         "tests":[
             {
-                "params":["vs", "Virtualization Service", "new"],
+                "params":["new"],
                 "expected": ["its_vs_newItems", "Approval policy for new items for Service: Virtualization Service"]
             },
             {
-                "params":["vs", "Virtualization Service", "reconfigure"],
+                "params":["reconfigure"],
                 "expected": ["its_vs_2ndDay", "Approval policy for 2nd day actions for Service: Virtualization Service"]
             }
         ]
     },
 
     {
-        "name": "getITSBGEntNameAndDesc",
+        "name": "getBGEntNameAndDesc",
         "tests": [
             {
-                "params":["vs", "Virtualization Service"],
+                "params":[],
                 "expected": ["its_vs", "Service: Virtualization Service"]
             }
         ]
     },
 
     {
-        "name": "getITSSecurityGroupNameAndDesc",
+        "name": "getSecurityGroupNameAndDesc",
         "tests":[
             {
-                "params": ["vs", "its_vs", "SVC0007"],
+                "params": ["its_vs"],
                 "expected": ["sg.its_vs", "Tenant: itservices\\nBusiness Group: its_vs\\nSNOWID: SVC0007"]
             }
         ]
     },
 
     {
-        "name": "getITSSecurityTagName",
+        "name": "getSecurityTagName",
         "tests":[
             {
-                "params":["vs"],
+                "params":[],
                 "expected":"st.its_vs"
             }
         ]
     },
 
     {
-        "name": "getITSFirewallSectionNameAndDesc",
+        "name": "getFirewallSectionNameAndDesc",
         "tests": [
             {
-                "params":["vs"],
+                "params":[],
                 "expected": ["its_vs","Section for Tenant itservices and Service vs"]
             }
         ]   
     },
 
     {
-        "name": "getITSFirewallRuleNames",
+        "name": "getFirewallRuleNames",
         "tests":[
             {
-                "params":["vs"],
+                "params":[],
                 "expected":[
                     {
                         "tag": "allow-vs-in",
@@ -320,7 +320,7 @@
         "name": "getVMMachinePrefix",
         "tests":[
             {
-                "params": ["vs"],
+                "params": [],
                 "expected": "vs-t-"
             }
         ]
@@ -330,7 +330,7 @@
         "name": "getEntName",
         "tests":[
             {
-                "params": ["vs"],
+                "params": [],
                 "expected": "its_vs"
             }
         ]
@@ -340,7 +340,7 @@
         "name": "getEntDescription",
         "tests":[
             {
-                "params": ["Virtualization Service"],
+                "params": [],
                 "expected": "Service: Virtualization Service"
             }
         ]
@@ -370,7 +370,7 @@
         "name": "getBGName",
         "tests":[
             {
-                "params": ["vs"],
+                "params": [],
                 "expected": "its_vs"
             }
         ]

--- a/powershell/tests/test-namegenerator-itservices.json
+++ b/powershell/tests/test-namegenerator-itservices.json
@@ -1,5 +1,20 @@
 [
     {
+        "name": "initDetails",
+        "tests": [
+            {
+                "params": [
+                    {
+                        "serviceShortName": "vs",
+                        "serviceName": "Virtualization Service",
+                        "snowServiceId": "SVC0007"
+                    }
+                ],
+                "expected": null
+            }
+        ]
+    },
+    {
         "name": "getADGroupNameRegEx",
         "tests": [
             {

--- a/powershell/tests/test-namegenerator.ps1
+++ b/powershell/tests/test-namegenerator.ps1
@@ -27,13 +27,31 @@ $classTester = [ClassTester]::new()
 
 # ------------------------------------------
 # Tests pour le tenant EPFL
+$details = @{
+    facultyName = "SI"
+    facultyID = "12635"
+    unitName = "IDEV-ING"
+    unitID = "13031"
+}
+
 $nameGenerator = [NameGenerator]::new('test', 'epfl')
+$nameGenerator.initDetails($details)
+
 $jsonFile = ([IO.Path]::Combine("$PSScriptRoot", "test-namegenerator-epfl.json"))
 $classTester.runTests($jsonFile, $nameGenerator)
 
 # ------------------------------------------
 # Tests pour le tenant ITServices
+
+$details = @{
+    serviceShortName = "vs"
+    serviceName = "Virtualization Service"
+    snowServiceId = "SVC0007"
+}
+
 $nameGenerator = [NameGenerator]::new('test', 'itservices')
+$nameGenerator.initDetails($details)
+
 $jsonFile = ([IO.Path]::Combine("$PSScriptRoot", "test-namegenerator-itservices.json"))
 $classTester.runTests($jsonFile, $nameGenerator)
 

--- a/powershell/tests/test-namegenerator.ps1
+++ b/powershell/tests/test-namegenerator.ps1
@@ -27,15 +27,8 @@ $classTester = [ClassTester]::new()
 
 # ------------------------------------------
 # Tests pour le tenant EPFL
-$details = @{
-    facultyName = "SI"
-    facultyID = "12635"
-    unitName = "IDEV-ING"
-    unitID = "13031"
-}
 
 $nameGenerator = [NameGenerator]::new('test', 'epfl')
-$nameGenerator.initDetails($details)
 
 $jsonFile = ([IO.Path]::Combine("$PSScriptRoot", "test-namegenerator-epfl.json"))
 $classTester.runTests($jsonFile, $nameGenerator)
@@ -43,18 +36,10 @@ $classTester.runTests($jsonFile, $nameGenerator)
 # ------------------------------------------
 # Tests pour le tenant ITServices
 
-$details = @{
-    serviceShortName = "vs"
-    serviceName = "Virtualization Service"
-    snowServiceId = "SVC0007"
-}
-
 $nameGenerator = [NameGenerator]::new('test', 'itservices')
-$nameGenerator.initDetails($details)
 
 $jsonFile = ([IO.Path]::Combine("$PSScriptRoot", "test-namegenerator-itservices.json"))
 $classTester.runTests($jsonFile, $nameGenerator)
-
 
 # Affichage des résultats
 $classTester.getResults().display("Test results")


### PR DESCRIPTION
- Changements dans la classe `NameGenerator` pour faire en sorte de ne plus avoir de fonctions nommées en fonction des Tenants. On va bientôt avoir un nouveau tenant pour les projets donc ça aurait impliqué d'ajouter de nouvelles fonctions. Pour la suite, il faut voir si on ne peut pas utiliser un fichier JSON de ressources pour le nommage au lieu de tout coder, histoire de rendre le truc un peu plus générique encore.
- Adaptation des tests de la classe (et correction de 4 d'entre eux car incorrects avant... mais peut-être que cette combinaison de paramètre n'avais jamais été utilisée...).
- Adaptation des scripts qui utilisent `NameGenerator` pour la nouvelle manière de fonctionner.
- Ajout de la gestion des paramètres de type `Array` et `Hashtable` pour les valeurs d'entrées des fonctions de tests
- Ajout de la gestion d'une valeur `null` comme retour d'une fonction à tester, pour dire qu'il n'y a pas de retour à contrôler (utile par exemple pour la fonction qui permet d'intialiser la classe `NameGenerator` avant de pouvoir l'utiliser).